### PR TITLE
A faster Zhang-Li STT test than STP 5

### DIFF
--- a/test/mumax3/test_mumax3_ZhangLi_STT.py
+++ b/test/mumax3/test_mumax3_ZhangLi_STT.py
@@ -5,7 +5,7 @@ from mumax3 import Mumax3Simulation
 from mumaxplus import Ferromagnet, Grid, World
 from mumaxplus.util import *
 
-RTOL = 2e-2  # 2%
+RTOL = 1e-5  # 0.001%
 
 def max_relative_error(result, wanted):
     err = np.linalg.norm(result - wanted, axis=0)
@@ -53,7 +53,6 @@ def simulations(request):
             J = vector{tuple(jcur)}
 
             saveas(STTorque, "STT.ovf")
-            SaveAs(torque, "torque.ovf")
         """
     )
 
@@ -82,4 +81,9 @@ class TestZhangLi:
     def test_STT(self, simulations):
         world, magnet, mumax3sim = simulations
         err = max_relative_error(magnet.spin_transfer_torque.eval(), mumax3sim.get_field("STT") * GAMMALL)
+        assert err < RTOL
+    
+    def test_total(self, simulations):
+        world, magnet, mumax3sim = simulations
+        err = max_relative_error(magnet.torque.eval() - magnet.llg_torque.eval(), magnet.spin_transfer_torque.eval())
         assert err < RTOL


### PR DESCRIPTION
This is a new Zhang-Li STT test. The test initialises a MuMax3 and MuMax+ simulation with Zhang-Li STT. It then compares both initial STTs. This is a way faster test than Standard Problem 5, however it does not run a simulation.