### PR TITLE
Add a free layer thickness test

### DIFF
--- a/test/test_free_layer_thickness.py
+++ b/test/test_free_layer_thickness.py
@@ -26,7 +26,7 @@ def relative_error(result, wanted):
     relerr = err / np.linalg.norm(wanted, axis=0)
     return relerr
 
-def simulation():
+def test_free_layer():
     # === Create a simulation ==
     world_wanted = World(cellsize=(1e-9, 1e-9, 1e-9))
     magnet_wanted = Ferromagnet(world_wanted, Grid((1, 1, 2)))
@@ -53,9 +53,5 @@ def simulation():
 
     torque_result = magnet_wanted.spin_transfer_torque.eval()[:,0,0,0]
 
-    return torque_result, torque_wanted
-
-def test_free_layer():
-    result, wanted = simulation()
-    err = relative_error(result, wanted)
+    err = relative_error(torque_result, torque_wanted)
     assert err < RTOL


### PR DESCRIPTION
This is one of three STT tests in MuMax3. It compares the torque of a simulation which is 2 cells thick with one where it is 4 cells thick (but two of those are empty). Both results should be the same (and they are 🎉 ).