### PR TITLE
Change twodomain to be like mumax3

### DIFF
--- a/examples/Bloch_wall.py
+++ b/examples/Bloch_wall.py
@@ -27,7 +27,7 @@ magnet.ku1 = 1.27e6
 magnet.anisU = (0, 0, 1)
 
 # --- Create a Bloch wall ---
-magnet.magnetization = twodomain((0, 0, -1), (0, 0, 1), (1, 1, 0), length/2, 3e-9)
+magnet.magnetization = twodomain((0, 0, -1), (1, 1, 0), (0, 0, 1), length/2, 3e-9)
 
 # --- Set up simulation parameters ---
 mx, my = [], []
@@ -54,4 +54,4 @@ plt.ylim(-0.001, 0.1)
 plt.xlabel(r"$D_{int}$ (mJ/m²)")
 plt.ylabel("Domain wall moments (a.u.)")
 plt.legend()
-plt.show()
+plt.savefig("bloch.png")

--- a/mumaxplus/util/config.py
+++ b/mumaxplus/util/config.py
@@ -2,7 +2,7 @@
 
 import numpy as _np
 
-def twodomain(m1, m2, mw, wallposition, wallthickness=0.):
+def twodomain(m1, mw, m2, wallposition, wallthickness=0.):
     """Return a two-domain state magnetization configuration
     with a domain wall which is perpendicular to the x-axis.
 


### PR DESCRIPTION
As the title says, I have changed the `twodomain` function to be more like MuMax³. So now the wall has a shape of a Gaussian function instead of a discrete transition. It is still possible to have a wall with a thickness of 0, then there is no smooth transition from the left to the right.