### PR TITLE
Update versions of CMake, Python and pybind11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.24)
 project(mumaxplus LANGUAGES CUDA CXX)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -15,15 +15,7 @@ if (WIN32)
     set(CMAKE_CUDA_RESOLVE_DEVICE_SYMBOLS TRUE)
 endif()
 
-# automatically detect best CUDA architecture
-# this is bad undocumented code which works
-# https://stackoverflow.com/a/68223399
-include(FindCUDA/select_compute_arch)
-CUDA_DETECT_INSTALLED_GPUS(INSTALLED_GPU_CCS_1)
-string(STRIP "${INSTALLED_GPU_CCS_1}" INSTALLED_GPU_CCS_2)
-string(REPLACE " " ";" INSTALLED_GPU_CCS_3 "${INSTALLED_GPU_CCS_2}")
-string(REPLACE "." "" CUDA_ARCH_LIST "${INSTALLED_GPU_CCS_3}")
-SET(CMAKE_CUDA_ARCHITECTURES ${CUDA_ARCH_LIST})
+set(CMAKE_CUDA_ARCHITECTURES native)
 
 add_definitions(-DFP_PRECISION=SINGLE) # FP_PRECISION should be SINGLE or DOUBLE
 add_definitions(-D_USE_MATH_DEFINES) # Needed for cmath constants on Windows

--- a/README.md
+++ b/README.md
@@ -18,15 +18,13 @@ You should install these yourself
 * On Windows (good luck): MSVC 2019
 
 These will be installed automatically within the conda environment
-* cmake 3.16
-* Python 3.8
-* pybind11 v2.5
+* cmake 3.31.1
+* Python 3.13
+* pybind11 v2.13.6
 * NumPy
 * matplotlib
 * SciPy
 * Sphinx
-
-As of now, we are stuck with Python 3.8, because newer versions of pybind11 do not work well with CUDA. We are working on a (clean) way around this issue.
 
 ## Installation from Source
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,12 +3,12 @@ channels:
   - conda-forge
 dependencies:
   # required
-  - python=3.8
+  - python=3.13
   - conda-build
   - pytest
   - matplotlib
   - numpy
-  - cmake=3.16.3
+  - cmake=3.31.1
   - scipy
 
   # code checks

--- a/src/bindings/CMakeLists.txt
+++ b/src/bindings/CMakeLists.txt
@@ -1,5 +1,9 @@
 project(mumaxplus)
 
+# disable pybind11::(thin_)lto, as this does not work with CUDA
+# https://github.com/pybind/pybind11/issues/4825
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)
+
 add_subdirectory(pybind11)
 
 pybind11_add_module(_mumaxpluscpp

--- a/test/mumax3/test_mumax3_Slonczewski_STT.py
+++ b/test/mumax3/test_mumax3_Slonczewski_STT.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+import math
 
 from mumax3 import Mumax3Simulation
 from mumaxplus import Ferromagnet, Grid, World
@@ -34,7 +35,7 @@ def simulations(request):
     epsilon_prime = 1
     jz = -6e-3/(length*width)
     jcur = (0, 0, jz)
-    mp = (np.cos(20*np.pi/180), np.sin(20*np.pi/180), 0)  # fixed layer mag
+    mp = (math.cos(20*np.pi/180), math.sin(20*np.pi/180), 0)  # fixed layer mag
 
     max_time = 0.5e-9
     step_time = 0.5e-12


### PR DESCRIPTION
- Update CMake 3.16 to 3.31.1, with minimum of 3.24 for clean automatic CUDA architecture detection
- Update Python from 3.8 to 3.13
- Update pybind11 from ~v2.4 to v2.13.6
- Set CMAKE_INTERPROCEDURAL_OPTIMIZATION to OFF to disable pybind::(thin_)lto
- Fix mumax3 Slonczewski test after Python (NumPy) update

This changes both the conda environment and the pybind11 submodule. Please test out if everything works on your machines too before merging. After checking out this branch, update the conda environment with
```bash
conda env update --file environment.yml
```
and update pybind11 with
```bash
git update submodule
```
Afterwards (or maybe even before), git might keep bothering you about uncommitted pybind11 changes. You might need to go into the `src/bindings/pybind11/` directory, run `git status` yourself and remove unwanted directories or undo unwanted changes. (A totally new user will not need to do this.)