### PR TITLE
Fixed pybind11 bug

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "src/bindings/pybind11"]
 	path = src/bindings/pybind11
 	url = https://github.com/pybind/pybind11
+	branch = v2.6.2


### PR DESCRIPTION
- pybind11 v2.5 has a bug which shows during compilation 
`error: 'uint16_t' in namespace 'std' does not name a type; did you mean 'wint_t'?`
- README's `clone --recursive` currently points to v2.5
- Easier to just force any version greater than v2.6 rather than rewriting files with `uint16_t` references to a compatible type