### PR TITLE
Add the possibility to set a strain

### DIFF
--- a/mumaxplus/ferromagnet.py
+++ b/mumaxplus/ferromagnet.py
@@ -1033,6 +1033,7 @@ class Ferromagnet(Magnet):
         See Also
         --------
         B1, B2
+        strain_tensor, rigid_norm_strain, rigid_shear_strain
         magnetoelastic_force
         """
         return FieldQuantity(_cpp.magnetoelastic_field(self._impl))

--- a/mumaxplus/magnet.py
+++ b/mumaxplus/magnet.py
@@ -12,7 +12,7 @@ from .scalarquantity import ScalarQuantity
 from .strayfield import StrayField
 from .variable import Variable
 
-
+import warnings
 class Magnet(ABC):
     """A Magnet should never be initialized by the user. It contains no physics.
     Use ``Ferromagnet`` or ``Antiferromagnet`` instead.
@@ -222,6 +222,10 @@ class Magnet(ABC):
     @enable_elastodynamics.setter
     def enable_elastodynamics(self, value):
         self._impl.enable_elastodynamics = value
+        if _np.any(self.rigid_norm_strain.eval() != 0):
+            raise Exception("You can not use normalized strain with elastodynamics.")
+        elif _np.any(self.rigid_shear_strain.eval() != 0):
+            raise Exception("You can not use shear strain with elastodynamics.")
 
     # ----- ELASTIC PARAMETERS -------
 
@@ -322,6 +326,8 @@ class Magnet(ABC):
     
     @rigid_norm_strain.setter
     def rigid_norm_strain(self, value):
+        if self.enable_elastodynamics:
+            raise Exception("You can not use elastodynamics with normal strain.")
         self.rigid_norm_strain.set(value)
     
     @property
@@ -343,6 +349,8 @@ class Magnet(ABC):
 
     @rigid_shear_strain.setter
     def rigid_shear_strain(self, value):
+        if self.enable_elastodynamics:
+            raise Exception("You can not use elastodynamics with shear strain.")
         self.rigid_shear_strain.set(value)
 
     # ----- ELASTIC QUANTITIES -------

--- a/mumaxplus/magnet.py
+++ b/mumaxplus/magnet.py
@@ -303,6 +303,48 @@ class Magnet(ABC):
     def rho(self, value):
         self.rho.set(value)
 
+    @property
+    def rigid_norm_strain(self):
+        """The applied normal strain (m/m).
+
+        This quantity has three components (εxx, εyy, εzz),
+        which forms the diagonal of the symmetric strain tensor::
+
+               εxx  0   0
+                0  εyy  0
+                0   0  εzz
+
+        See Also
+        --------
+        elastic_energy, elastic_energy_density, elastic_displacement, stress_tensor
+        """
+        return Parameter(self._impl.rigid_norm_strain)
+    
+    @rigid_norm_strain.setter
+    def rigid_norm_strain(self, value):
+        self.rigid_norm_strain.set(value)
+    
+    @property
+    def rigid_shear_strain(self):
+        """The applied shear strain (m/m).
+
+        This quantity has three components (εxy, εxz, εyz),
+        which forms the off-diagonal of the symmetric strain tensor::
+
+                 0  εxy εxz
+                εxy  0  εyz
+                εxz εyz  0
+
+        See Also
+        --------
+        elastic_energy, elastic_energy_density, elastic_displacement, stress_tensor
+        """
+        return Parameter(self._impl.rigid_shear_strain)
+
+    @rigid_shear_strain.setter
+    def rigid_shear_strain(self, value):
+        self.rigid_shear_strain.set(value)
+
     # ----- ELASTIC QUANTITIES -------
 
     @property

--- a/mumaxplus/magnet.py
+++ b/mumaxplus/magnet.py
@@ -222,10 +222,11 @@ class Magnet(ABC):
     @enable_elastodynamics.setter
     def enable_elastodynamics(self, value):
         self._impl.enable_elastodynamics = value
-        if _np.any(self.rigid_norm_strain.eval() != 0):
-            raise Exception("You can not use normalized strain with elastodynamics.")
-        elif _np.any(self.rigid_shear_strain.eval() != 0):
-            raise Exception("You can not use shear strain with elastodynamics.")
+        if value:
+            if _np.any(self.rigid_norm_strain.eval() != 0):
+                raise Exception("You can not use normalized strain with elastodynamics.")
+            elif _np.any(self.rigid_shear_strain.eval() != 0):
+                raise Exception("You can not use shear strain with elastodynamics.")
 
     # ----- ELASTIC PARAMETERS -------
 

--- a/src/bindings/wrap_magnet.cpp
+++ b/src/bindings/wrap_magnet.cpp
@@ -39,6 +39,8 @@ void wrap_magnet(py::module& m) {
       .def_readonly("C44", &Magnet::C44)
       .def_readonly("eta", &Magnet::eta)
       .def_readonly("rho", &Magnet::rho)
+      .def_readonly("rigid_norm_strain", &Magnet::rigidNormStrain)
+      .def_readonly("rigid_shear_strain", &Magnet::rigidShearStrain)
 
       .def("stray_field_from_magnet",
           [](const Magnet* m, Magnet* magnet) {

--- a/src/core/parameter.hpp
+++ b/src/core/parameter.hpp
@@ -161,6 +161,10 @@ struct CuVectorParameter {
  public:
   explicit CuVectorParameter(const VectorParameter*);
   __device__ bool isUniform() const;
+
+  __device__ real valueAt(int idx, int comp = 0) const;
+  __device__ real valueAt(int3 coo, int comp = 0) const;
+
   __device__ real3 vectorAt(int idx) const;
   __device__ real3 vectorAt(int3 coo) const;
 };
@@ -189,6 +193,25 @@ inline CuVectorParameter::CuVectorParameter(const VectorParameter* p)
 
 __device__ inline bool CuVectorParameter::isUniform() const {
   return !xValuesPtr;
+}
+
+__device__ inline real CuVectorParameter::valueAt(int idx, int comp) const {
+  real sv, dv;  // static and dynamic values
+  if (comp == 0) {  // x
+    sv = isUniform() ? uniformValue.x : xValuesPtr[idx];
+    dv = xDynamicValuesPtr ? xDynamicValuesPtr[idx] : 0.;
+  } else if (comp == 1) {  // y
+    sv = isUniform() ? uniformValue.y : yValuesPtr[idx];
+    dv = yDynamicValuesPtr ? yDynamicValuesPtr[idx] : 0.;
+  } else {  // z  comp == 2 (no safety checks)
+    sv = isUniform() ? uniformValue.z : zValuesPtr[idx];
+    dv = zDynamicValuesPtr ? zDynamicValuesPtr[idx] : 0.;
+  }
+  return sv + dv;
+}
+
+__device__ inline real CuVectorParameter::valueAt(int3 coo, int comp) const {
+  return valueAt(system.grid.coord2index(coo), comp);
 }
 
 __device__ inline real3 CuVectorParameter::vectorAt(int idx) const {

--- a/src/physics/effectivefield.cpp
+++ b/src/physics/effectivefield.cpp
@@ -19,7 +19,7 @@ Field evalEffectiveField(const Ferromagnet* magnet) {
   if (!externalFieldAssuredZero(magnet)) {h += evalExternalField(magnet);}
   if (!dmiAssuredZero(magnet)) {h += evalDmiField(magnet);}
   if (!demagFieldAssuredZero(magnet)) {h += evalDemagField(magnet);}
-  if (!magnetoelasticAssuredZero(magnet) || appliedStrain(magnet)) {
+  if (!magnetoelasticAssuredZero(magnet)) {
       h += evalMagnetoelasticField(magnet);}
   if (magnet->isSublattice())
       if (!inHomoAfmExchangeAssuredZero(magnet)) {h += evalInHomogeneousAfmExchangeField(magnet);}

--- a/src/physics/effectivefield.cpp
+++ b/src/physics/effectivefield.cpp
@@ -19,7 +19,8 @@ Field evalEffectiveField(const Ferromagnet* magnet) {
   if (!externalFieldAssuredZero(magnet)) {h += evalExternalField(magnet);}
   if (!dmiAssuredZero(magnet)) {h += evalDmiField(magnet);}
   if (!demagFieldAssuredZero(magnet)) {h += evalDemagField(magnet);}
-  if (!magnetoelasticAssuredZero(magnet)) {h += evalMagnetoelasticField(magnet);}
+  if (!magnetoelasticAssuredZero(magnet) || appliedStrain(magnet)) {
+      h += evalMagnetoelasticField(magnet);}
   if (magnet->isSublattice())
       if (!inHomoAfmExchangeAssuredZero(magnet)) {h += evalInHomogeneousAfmExchangeField(magnet);}
       if (!homoAfmExchangeAssuredZero(magnet)) {h += evalHomogeneousAfmExchangeField(magnet);}

--- a/src/physics/magnet.cpp
+++ b/src/physics/magnet.cpp
@@ -29,7 +29,9 @@ Magnet::Magnet(std::shared_ptr<System> system_ptr,
       C12(system(), 0.0, name + ":C12", "N/m2"),
       C44(system(), 0.0, name + ":C44", "N/m2"),
       eta(system(), 0.0, name + ":eta", "kg/m3s"),
-      rho(system(), 1.0, name + ":rho", "kg/m3") {
+      rho(system(), 1.0, name + ":rho", "kg/m3"),
+      rigidNormStrain(system(), {0.0, 0.0, 0.0}, name + ":rigid_norm_strain", ""),
+      rigidShearStrain(system(), {0.0, 0.0, 0.0}, name + ":rigid_shear_strain", "") {
   // Check that the system has at least size 1
   int3 size = system_->grid().size();
   if (size.x < 1 || size.y < 1 || size.z < 1)
@@ -51,7 +53,8 @@ Magnet::Magnet(Magnet&& other) noexcept
       
       externalBodyForce(other.externalBodyForce),
       C11(other.C11), C12(other.C12), C44(other.C44),
-      eta(other.eta), rho(other.rho) {
+      eta(other.eta), rho(other.rho), rigidNormStrain(other.rigidNormStrain),
+      rigidShearStrain(other.rigidShearStrain) {
   other.system_ = nullptr;
   other.name_ = "";
 }

--- a/src/physics/magnet.cpp
+++ b/src/physics/magnet.cpp
@@ -184,6 +184,13 @@ void Magnet::setEnableElastodynamics(bool value) {
     }
   }
 
+  // should not use elastodynamics together with rigid strain!
+  if (value && (!this->rigidNormStrain.assuredZero() ||
+                !this->rigidShearStrain.assuredZero())) {
+    throw std::invalid_argument(
+      "Cannot enable elastodynamics when rigid strain is set.");
+  }
+
   if (enableElastodynamics_ != value) {
     enableElastodynamics_ = value;
 

--- a/src/physics/magnet.hpp
+++ b/src/physics/magnet.hpp
@@ -73,6 +73,8 @@ class Magnet {
   const Variable* elasticVelocity() const;
 
   VectorParameter externalBodyForce;  // Externally applied force density
+  VectorParameter rigidNormStrain;
+  VectorParameter rigidShearStrain;
 
   // stiffness constants; TODO: can this be generalized to a 6x6 tensor?
   Parameter C11;  // C11 = c22 = c33

--- a/src/physics/magnetoelasticfield.cu
+++ b/src/physics/magnetoelasticfield.cu
@@ -20,6 +20,10 @@ bool magnetoelasticAssuredZero(const Ferromagnet* magnet) {
           (magnet->B1.assuredZero() && magnet->B2.assuredZero()));
 }
 
+bool appliedStrain(const Magnet* magnet) {
+  return (!magnet->rigidNormStrain.assuredZero() || !magnet->rigidShearStrain.assuredZero());
+}
+
 __global__ void k_magnetoelasticField(CuField hField,
                                       const CuField mField,
                                       const CuField strain,
@@ -51,10 +55,55 @@ __global__ void k_magnetoelasticField(CuField hField,
   }
 }
 
+__global__ void k_rigidMagnetoelasticField(CuField hField,
+                                           const CuField mField,
+                                           const CuField normStrain,
+                                           const CuField shearStrain,
+                                           const CuParameter B1,
+                                           const CuParameter B2,
+                                           const CuParameter msat) {
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const CuSystem system = hField.system;
+  const Grid grid = system.grid;
+  // When outside the geometry, set to zero and return early
+  if (!system.inGeometry(idx)) {
+    if (grid.cellInGrid(idx)) {
+      hField.setVectorInCell(idx, real3{0, 0, 0});
+    }
+    return;
+  }
+
+  int ip1, ip2;
+  for (int i=0; i<3; i++) {
+    ip1 = i+1; ip2 = i+2;
+    // If they exceed 3, loop around
+    if (ip1 >= 3) ip1 -= 3;
+    if (ip2 >= 3) ip2 -= 3;
+
+    hField.setValueInCell(idx, i, - 2 / msat.valueAt(idx) *
+    (B1.valueAt(idx) *  normStrain.valueAt(idx, i)        * mField.valueAt(idx, i)   + 
+     B2.valueAt(idx) * (shearStrain.valueAt(idx, i+ip1-1) * mField.valueAt(idx, ip1) + 
+                        shearStrain.valueAt(idx, i+ip2-1) * mField.valueAt(idx, ip2))));
+  }
+}
+
 Field evalMagnetoelasticField(const Ferromagnet* magnet) {
   Field hField(magnet->system(), 3);
-  if (magnetoelasticAssuredZero(magnet)) {
+  if (magnetoelasticAssuredZero(magnet) && !appliedStrain(magnet)) {
     hField.makeZero();
+    return hField;
+  }
+
+  int ncells = hField.grid().ncells();
+  CuField mField = magnet->magnetization()->field().cu();
+  CuParameter B1 = magnet->B1.cu();
+  CuParameter B2 = magnet->B2.cu();
+  CuParameter msat = magnet->msat.cu();
+
+  if (appliedStrain(magnet)) {
+    Field normStrain = magnet->rigidNormStrain.eval();
+    Field shearStrain = magnet->rigidShearStrain.eval();
+    cudaLaunch(ncells, k_rigidMagnetoelasticField, hField.cu(), mField, normStrain.cu(), shearStrain.cu(), B1, B2, msat);
     return hField;
   }
 
@@ -64,12 +113,6 @@ Field evalMagnetoelasticField(const Ferromagnet* magnet) {
   } else {  // independent magnet
     strain = evalStrainTensor(magnet);
   }
-
-  int ncells = hField.grid().ncells();
-  CuField mField = magnet->magnetization()->field().cu();
-  CuParameter B1 = magnet->B1.cu();
-  CuParameter B2 = magnet->B2.cu();
-  CuParameter msat = magnet->msat.cu();
 
   cudaLaunch(ncells, k_magnetoelasticField, hField.cu(), mField, strain.cu(), B1, B2, msat);
   return hField;

--- a/src/physics/magnetoelasticfield.hpp
+++ b/src/physics/magnetoelasticfield.hpp
@@ -8,7 +8,8 @@ class Field;
 
 // Assure that the magnetoelastic field and force are 0
 bool magnetoelasticAssuredZero(const Ferromagnet*);
-bool appliedStrain(const Magnet*);
+bool dynamicMagnetoelasticAssuredZero(const Ferromagnet*);
+bool rigidMagnetoelasticAssuredZero(const Ferromagnet*);
 
 Field evalMagnetoelasticField(const Ferromagnet*);
 Field evalMagnetoelasticEnergyDensity(const Ferromagnet*);

--- a/src/physics/magnetoelasticfield.hpp
+++ b/src/physics/magnetoelasticfield.hpp
@@ -8,6 +8,7 @@ class Field;
 
 // Assure that the magnetoelastic field and force are 0
 bool magnetoelasticAssuredZero(const Ferromagnet*);
+bool appliedStrain(const Magnet*);
 
 Field evalMagnetoelasticField(const Ferromagnet*);
 Field evalMagnetoelasticEnergyDensity(const Ferromagnet*);

--- a/test/mumax3/test_mumax3_rigid_strain.py
+++ b/test/mumax3/test_mumax3_rigid_strain.py
@@ -4,7 +4,7 @@ from mumax3 import Mumax3Simulation
 from mumaxplus import Ferromagnet, Grid, World
 from mumaxplus.util import formulary
 
-RTOL = 1e-7  # floating point :)
+RTOL = 3e-5
 strain = 1e-4
 
 def max_relative_error(result, wanted):
@@ -16,7 +16,6 @@ def simulation(exx, eyy, ezz, exy, exz, eyz):
     # arbitrarily chosen parameters
     msat, aex, alpha = 566e3, 2.48e-12, 0.02
     B = -55e6
-    magnetization = (1,1,1)
     cellsize = (1e-9, 2e-9, 3.2e-9)
     gridsize = (30, 16, 4)
 
@@ -36,7 +35,8 @@ def simulation(exx, eyy, ezz, exy, exz, eyz):
             B1 = {B}
             B2 = {B}
 
-            m = Uniform{tuple(magnetization)}
+            m = randommag()
+            saveas(m, "m.ovf")
             saveas(B_mel, "B.ovf")
         """
     )
@@ -46,7 +46,7 @@ def simulation(exx, eyy, ezz, exy, exz, eyz):
     magnet.msat = msat
     magnet.aex = aex
     magnet.alpha = alpha
-    magnet.magnetization = magnetization
+    magnet.magnetization.set(mumax3sim.get_field("m"))
     magnet.rigid_norm_strain = (exx, eyy, ezz)
     magnet.rigid_shear_strain = (exy, exz, eyz)
     magnet.B1 = B
@@ -58,7 +58,6 @@ def simulation(exx, eyy, ezz, exy, exz, eyz):
 @pytest.mark.mumax3
 class TestRigidStrain:
     """Test rigid strain against mumax³."""
-
     def test_exx(self):
         exx, eyy, ezz, exy, exz, eyz = strain, 0, 0, 0, 0, 0
         magnet, mumax3sim = simulation(exx, eyy, ezz, exy, exz, eyz)
@@ -103,6 +102,15 @@ class TestRigidStrain:
 
     def test_eyz(self):
         exx, eyy, ezz, exy, exz, eyz = 0, 0, 0, 0, 0, strain
+        magnet, mumax3sim = simulation(exx, eyy, ezz, exy, exz, eyz)
+        wanted = mumax3sim.get_field("B")
+        result = magnet.magnetoelastic_field.eval()
+        err = max_relative_error(result, wanted)
+        assert err < RTOL
+
+    def test_combined(self):
+        exx, eyy, ezz = -strain, -strain, -strain
+        exy, exz, eyz = -strain, -strain, -strain
         magnet, mumax3sim = simulation(exx, eyy, ezz, exy, exz, eyz)
         wanted = mumax3sim.get_field("B")
         result = magnet.magnetoelastic_field.eval()

--- a/test/mumax3/test_mumax3_rigid_strain.py
+++ b/test/mumax3/test_mumax3_rigid_strain.py
@@ -1,0 +1,110 @@
+import numpy as np
+import pytest
+from mumax3 import Mumax3Simulation
+from mumaxplus import Ferromagnet, Grid, World
+from mumaxplus.util import formulary
+
+RTOL = 1e-7  # floating point :)
+strain = 1e-4
+
+def max_relative_error(result, wanted):
+    err = np.linalg.norm(result - wanted, axis=0)
+    relerr = err / np.linalg.norm(wanted, axis=0)
+    return np.max(relerr)
+
+def simulation(exx, eyy, ezz, exy, exz, eyz):
+    # arbitrarily chosen parameters
+    msat, aex, alpha = 566e3, 2.48e-12, 0.02
+    B = -55e6
+    magnetization = (1,1,1)
+    cellsize = (1e-9, 2e-9, 3.2e-9)
+    gridsize = (30, 16, 4)
+
+    mumax3sim = Mumax3Simulation(
+        f"""
+            setcellsize{cellsize}
+            setgridsize{gridsize}
+            msat = {msat}
+            aex = {aex}
+            alpha = {alpha}
+            exx = {exx}
+            eyy = {eyy}
+            ezz = {ezz}
+            exy = {exy}
+            exz = {exz}
+            eyz = {eyz}
+            B1 = {B}
+            B2 = {B}
+
+            m = Uniform{tuple(magnetization)}
+            saveas(B_mel, "B.ovf")
+        """
+    )
+
+    world = World(cellsize)
+    magnet = Ferromagnet(world, Grid(gridsize))
+    magnet.msat = msat
+    magnet.aex = aex
+    magnet.alpha = alpha
+    magnet.magnetization = magnetization
+    magnet.rigid_norm_strain = (exx, eyy, ezz)
+    magnet.rigid_shear_strain = (exy, exz, eyz)
+    magnet.B1 = B
+    magnet.B2 = B
+
+    return magnet, mumax3sim
+
+
+@pytest.mark.mumax3
+class TestRigidStrain:
+    """Test rigid strain against mumax³."""
+
+    def test_exx(self):
+        exx, eyy, ezz, exy, exz, eyz = strain, 0, 0, 0, 0, 0
+        magnet, mumax3sim = simulation(exx, eyy, ezz, exy, exz, eyz)
+        wanted = mumax3sim.get_field("B")
+        result = magnet.magnetoelastic_field.eval()
+        err = max_relative_error(result, wanted)
+        assert err < RTOL
+
+    def test_eyy(self):
+        exx, eyy, ezz, exy, exz, eyz = 0, strain, 0, 0, 0, 0
+        magnet, mumax3sim = simulation(exx, eyy, ezz, exy, exz, eyz)
+        wanted = mumax3sim.get_field("B")
+        result = magnet.magnetoelastic_field.eval()
+        err = max_relative_error(result, wanted)
+        assert err < RTOL
+
+    def test_ezz(self):
+        exx, eyy, ezz, exy, exz, eyz = 0, 0, strain, 0, 0, 0
+        magnet, mumax3sim = simulation(exx, eyy, ezz, exy, exz, eyz)
+        wanted = mumax3sim.get_field("B")
+        result = magnet.magnetoelastic_field.eval()
+        err = max_relative_error(result, wanted)
+        assert err < RTOL
+
+    def test_exy(self):
+        exx, eyy, ezz, exy, exz, eyz = 0, 0, 0, strain, 0, 0
+        magnet, mumax3sim = simulation(exx, eyy, ezz, exy, exz, eyz)
+        wanted = mumax3sim.get_field("B")
+        result = magnet.magnetoelastic_field.eval()
+        print(np.any(wanted != 0))
+        print(np.any(result != 0))
+        err = max_relative_error(result, wanted)
+        assert err < RTOL
+
+    def test_exz(self):
+        exx, eyy, ezz, exy, exz, eyz = 0, 0, 0, 0, strain, 0
+        magnet, mumax3sim = simulation(exx, eyy, ezz, exy, exz, eyz)
+        wanted = mumax3sim.get_field("B")
+        result = magnet.magnetoelastic_field.eval()
+        err = max_relative_error(result, wanted)
+        assert err < RTOL
+
+    def test_eyz(self):
+        exx, eyy, ezz, exy, exz, eyz = 0, 0, 0, 0, 0, strain
+        magnet, mumax3sim = simulation(exx, eyy, ezz, exy, exz, eyz)
+        wanted = mumax3sim.get_field("B")
+        result = magnet.magnetoelastic_field.eval()
+        err = max_relative_error(result, wanted)
+        assert err < RTOL

--- a/test/mumax3/test_mumax3_rigid_strain.py
+++ b/test/mumax3/test_mumax3_rigid_strain.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 from mumax3 import Mumax3Simulation
 from mumaxplus import Ferromagnet, Grid, World
-from mumaxplus.util import formulary
 
 RTOL = 3e-5
 strain = 1e-4


### PR DESCRIPTION
This code allows user to set a normal and/or shear strain. However, it is impossible to combine this with elastodynamics, because elastodynamics wants to modify strain based on displacement. If someone would try this, they get an error.
This pull request also includes a test where the magnetoelastic field from mumax⁺ is compared with mumax³ (the results are exactly the same up to floating points :sunglasses: ).