### PR TITLE
Voronoi PBC

### DIFF
--- a/mumaxplus/util/voronoi.py
+++ b/mumaxplus/util/voronoi.py
@@ -37,7 +37,7 @@ class VoronoiTessellator:
 
         # is this the cleanest way to check PBC?
         # do we need this check in the C++ module?
-        has_pbc = world.mastergrid != Grid((0,0,0)) and world.pbc_repetitions != (0,0,0)
+        has_pbc = world.pbc_repetitions != (0,0,0)
 
         self.tessellation = self._impl.generate(grid._impl, world.cellsize, has_pbc)
 
@@ -45,7 +45,13 @@ class VoronoiTessellator:
     
     def coo_to_idx(self, x, y, z):
         """Returns the region index (int) of the given coordinate within the
-        Voronoi tessellation."""
+        Voronoi tessellation.
+
+        **Important:** This method has no information about the used world and
+        grid. E.g. this means that periodic boundary conditions will not apply.
+        This can be overriden by calling `generate` before assinging this function
+        to the `Magnet`'s regions parameter.
+        """
         return self._impl.coo_to_idx((x,y,z))
 
     @property

--- a/mumaxplus/util/voronoi.py
+++ b/mumaxplus/util/voronoi.py
@@ -1,6 +1,8 @@
 import numpy as _np
 
 import _mumaxpluscpp as _cpp
+from mumaxplus.world import World
+from mumaxplus.grid import Grid
 class VoronoiTessellator:
 
     def __init__(self, grainsize, max_idx=256, seed=1234567):
@@ -32,7 +34,12 @@ class VoronoiTessellator:
 
         Returns an ndarray of shape (nz, ny, nx) which is filled
         with region indices."""
-        self.tessellation = self._impl.generate(grid._impl, world.cellsize)
+
+        # is this the cleanest way to check PBC?
+        # do we need this check in the C++ module?
+        has_pbc = world.mastergrid != Grid((0,0,0)) and world.pbc_repetitions != (0,0,0)
+
+        self.tessellation = self._impl.generate(grid._impl, world.cellsize, has_pbc)
 
         return self.tessellation
     

--- a/src/bindings/wrap_voronoi.cpp
+++ b/src/bindings/wrap_voronoi.cpp
@@ -17,8 +17,8 @@ void wrap_voronoi(py::module& m) {
                 py::arg("seed"))
         .def("coo_to_idx", &VoronoiTessellator::regionOf)
         // TODO: create template function (wrap_system.cpp)
-        .def("generate", [](VoronoiTessellator& t, Grid grid, real3 cellsize) {
-            unsigned int* tess = t.generate(grid, cellsize).getHostCopy();
+        .def("generate", [](VoronoiTessellator& t, Grid grid, real3 cellsize, const bool pbc) {
+            unsigned int* tess = t.generate(grid, cellsize, pbc).getHostCopy();
 
             // Create python capsule which will free tess
             py::capsule free_when_done(tess, [](void* p) {

--- a/src/core/voronoi.cpp
+++ b/src/core/voronoi.cpp
@@ -15,9 +15,31 @@ VoronoiTessellator::VoronoiTessellator(real grainsize, unsigned int maxIdx, int 
         lambda_ = tilesize_in_grains * tilesize_in_grains;
     }
 
+    real VoronoiTessellator::findTileSize(real grid_size, real grainsize) {
+        real min_tile_size = 2 * grainsize;
+        unsigned int N = std::max(1u, static_cast<unsigned int>(std::ceil(grid_size / min_tile_size)));
+        return grid_size / N;  // Adjusted tile size to fit the grid evenly
+    }
+
+
 GpuBuffer<unsigned int> VoronoiTessellator::generate(Grid grid, real3 cellsize) {
 
+    gridsize_ = grid.size();
+    cellsize_ = cellsize;
+
+    tilesize_x = findTileSize(grid.size().x*cellsize.x, grainsize_);
+    tilesize_y = findTileSize(grid.size().y*cellsize.y, grainsize_);
+
+    numTiles_x = static_cast<int>(std::ceil(grid.size().x * cellsize.x / tilesize_x));
+    numTiles_y = static_cast<int>(std::ceil(grid.size().y * cellsize.y / tilesize_y));
+
+    lambda_x = (tilesize_x / grainsize_) * (tilesize_x / grainsize_);
+    lambda_y = (tilesize_y / grainsize_) * (tilesize_y / grainsize_);
+
+   lambda_ = std::max(lambda_x, lambda_y);
+
    std::vector<unsigned int> data(grid.ncells());
+
    for (int nx = 0; nx < grid.size().x; nx++) {
         for (int ny = 0; ny < grid.size().y; ny++) {
             real3 coo = real3{nx * cellsize.x,
@@ -35,10 +57,17 @@ unsigned int VoronoiTessellator::regionOf(real3 coo) {
     real mindist = INFINITY;
     for (int tx = t.pos.x-1; tx <= t.pos.x+1; tx++) {
         for (int ty = t.pos.y-1; ty <= t.pos.y+1; ty++) {
-            std::vector<Center> centers = centersInTile(int3{tx, ty, 0});
+
+            int wrapped_tx = (tx + numTiles_x) % numTiles_x;
+            int wrapped_ty = (ty + numTiles_y) % numTiles_y;
+
+            std::vector<Center> centers = centersInTile(int3{wrapped_tx, wrapped_ty, 0});
+
             for (auto c : centers) {
-                real dist = (coo.x - c.pos.x) * (coo.x - c.pos.x)
-                          + (coo.y - c.pos.y) * (coo.y - c.pos.y);
+                real3 shifted_center = periodicShift(coo, c.pos, gridsize_.x*cellsize_.x, gridsize_.y*cellsize_.y);
+                real dist = (coo.x - shifted_center.x) * (coo.x - shifted_center.x)
+                        + (coo.y - shifted_center.y) * (coo.y - shifted_center.y);
+
                 if (dist < mindist) {
                     nearest = c;
                     mindist = dist;
@@ -47,6 +76,19 @@ unsigned int VoronoiTessellator::regionOf(real3 coo) {
         }
     }
     return nearest.ridx;
+}
+
+real3 VoronoiTessellator::periodicShift(real3 coo, real3 center, real grid_size_x, real grid_size_y) {
+    real dx = center.x - coo.x;
+    real dy = center.y - coo.y;
+
+    // Apply periodic boundary corrections
+    if (dx > grid_size_x * 0.5) dx -= grid_size_x;
+    if (dx < -grid_size_x * 0.5) dx += grid_size_x;
+    if (dy > grid_size_y * 0.5) dy -= grid_size_y;
+    if (dy < -grid_size_y * 0.5) dy += grid_size_y;
+
+    return real3{coo.x + dx, coo.y + dy, 0};
 }
 
 std::vector<Center> VoronoiTessellator::centersInTile(int3 pos) {
@@ -66,8 +108,8 @@ std::vector<Center> VoronoiTessellator::centersInTile(int3 pos) {
     std::vector<Center> centers(N);
 
     for (int n = 0; n < N; n++) {
-        real cx = (pos.x + distReal_(engine_)) * tilesize_;
-        real cy = (pos.y + distReal_(engine_)) * tilesize_;
+        real cx = (pos.x + distReal_(engine_)) * tilesize_x;
+        real cy = (pos.y + distReal_(engine_)) * tilesize_y;
 
         centers[n] = Center(real3{cx, cy, 0}, distInt_(engine_));
     }
@@ -87,8 +129,8 @@ int VoronoiTessellator::Poisson(real lambda) {
 }
 
 Tile VoronoiTessellator::tileOfCell(real3 coo) {
-    return Tile{int3{static_cast<int>(std::floor(coo.x / tilesize_)), // This cannot be the best way...
-                     static_cast<int>(std::floor(coo.y / tilesize_)),
+    return Tile{int3{static_cast<int>(std::floor(coo.x / tilesize_x)), // This cannot be the best way...
+                     static_cast<int>(std::floor(coo.y / tilesize_y)),
                      0}
             };
 }

--- a/src/core/voronoi.hpp
+++ b/src/core/voronoi.hpp
@@ -35,8 +35,12 @@ class VoronoiTessellator {
   // * Generate a Voronoi tessellation
   GpuBuffer<unsigned int> generate(Grid grid, real3 cellsize);
 
+  real findTileSize(real gridsize, real grainsize);
+
   // * Calc nearest center and assign center index to coo
   unsigned int regionOf(real3 coo);
+
+real3 periodicShift(real3 coo, real3 center, real gridx, real gridy);
 
   private:
   // * Calculate position and index of centers in tile
@@ -52,12 +56,20 @@ public:
   GpuBuffer<unsigned int> tessellation;
 private:
   real grainsize_;
+  int3 gridsize_;
+  real3 cellsize_;
   real tilesize_;
   int seed_;
+  real tilesize_x;
+  real tilesize_y;
+  int numTiles_x;
+  int numTiles_y;
   std::unordered_map<int3, Tile, Int3Hash> tileCache_;
 
  // RNG related members
   real lambda_; // Poisson parameter
+  real lambda_x;
+  real lambda_y;
   std::default_random_engine engine_;
   std::uniform_real_distribution<> distReal_;
   std::uniform_int_distribution<> distInt_;

--- a/src/core/voronoi.hpp
+++ b/src/core/voronoi.hpp
@@ -40,7 +40,7 @@ class VoronoiTessellator {
   // * Calc nearest center and assign center index to coo
   unsigned int regionOf(real3 coo);
 
-real3 periodicShift(real3 coo, real3 center, real3 gridsize);
+real3 periodicShift(real3 coo, real3 center);
 
   private:
   // * Calculate position and index of centers in tile
@@ -57,11 +57,13 @@ public:
 private:
   real grainsize_;
   real3 grid_dims_;
-  real3 tilesize_;
   bool pbc_;
-  int seed_;
+
+  real3 tilesize_;
   int numTiles_x;
   int numTiles_y;
+
+  int seed_;
   std::unordered_map<int3, Tile, Int3Hash> tileCache_;
 
  // RNG related members

--- a/src/core/voronoi.hpp
+++ b/src/core/voronoi.hpp
@@ -33,14 +33,14 @@ class VoronoiTessellator {
   ~VoronoiTessellator() = default;
 
   // * Generate a Voronoi tessellation
-  GpuBuffer<unsigned int> generate(Grid grid, real3 cellsize);
+  GpuBuffer<unsigned int> generate(Grid grid, real3 cellsize, const bool pbc);
 
-  real findTileSize(real gridsize, real grainsize);
+  real3 getTileSize(real3 griddims);
 
   // * Calc nearest center and assign center index to coo
   unsigned int regionOf(real3 coo);
 
-real3 periodicShift(real3 coo, real3 center, real gridx, real gridy);
+real3 periodicShift(real3 coo, real3 center, real3 gridsize);
 
   private:
   // * Calculate position and index of centers in tile
@@ -56,20 +56,16 @@ public:
   GpuBuffer<unsigned int> tessellation;
 private:
   real grainsize_;
-  int3 gridsize_;
-  real3 cellsize_;
-  real tilesize_;
+  real3 grid_dims_;
+  real3 tilesize_;
+  bool pbc_;
   int seed_;
-  real tilesize_x;
-  real tilesize_y;
   int numTiles_x;
   int numTiles_y;
   std::unordered_map<int3, Tile, Int3Hash> tileCache_;
 
  // RNG related members
   real lambda_; // Poisson parameter
-  real lambda_x;
-  real lambda_y;
   std::default_random_engine engine_;
   std::uniform_real_distribution<> distReal_;
   std::uniform_int_distribution<> distInt_;


### PR DESCRIPTION
Implementation of periodic boundary conditions in the Voronoi tesselator.

Periodicity implies that tiles can no longer (partially) exist outside `Grid`. This leads to a fudging of the tile size, so all tiles fit evenly, and the generalization to rectangular tiles.
This might not be the best option and there are surely edge cases where this logic breaks, but then again, the use of Voronoi regions is only physical with _decent_ parameters (grid size and grain size).