### PR TITLE
Fix cmd

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,11 +66,8 @@ class CMakeBuild(build_ext):
             ["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env
         )
         subprocess.check_call(
-            ["cmake", "--build", ".", "--target", "_mumaxpluscpp"] + build_args,
+            ["cmake", "--build", ".", "--target", "_mumaxpluscpp", "install"] + build_args,
             cwd=self.build_temp,
-        )
-        subprocess.check_call(
-            ["cmake", "--build", ".", "--target", "install"] + build_args, cwd=self.build_temp
         )
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,9 @@ class CMakeBuild(build_ext):
             ["cmake", "--build", ".", "--target", "_mumaxpluscpp"] + build_args,
             cwd=self.build_temp,
         )
-
+        subprocess.check_call(
+            ["cmake", "--build", ".", "--target", "install"] + build_args, cwd=self.build_temp
+        )
 
 setup(
     name="mumaxplus",

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -9,3 +9,5 @@ target_include_directories(cmd PRIVATE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
 
 target_link_libraries(cmd PUBLIC physics)
 target_link_libraries(cmd PUBLIC core)
+
+install(TARGETS cmd DESTINATION "$ENV{CONDA_PREFIX}/bin")

--- a/src/cmd/main.cpp
+++ b/src/cmd/main.cpp
@@ -5,7 +5,7 @@
 int main() {
   int example_number = 0;
 
-  std::cout << "************ Mumax C++ Exaples ************\n"
+  std::cout << "************ Mumax C++ Examples ************\n"
             << "1. Standard Problem 4.\n"
             << "2. Spinwave Dispersion.\n"
             << "*******************************************\n"

--- a/src/cmd/spinwave_dispersion.cpp
+++ b/src/cmd/spinwave_dispersion.cpp
@@ -37,7 +37,9 @@ void spinwave_dispersion() {
 
   MumaxWorld mWorld(cellsize);
   Grid mGrid(grid_size);
-  auto magnet = mWorld.addFerromagnet(mGrid, 3, ferromagnet_name);
+  GpuBuffer<bool> geometry;
+  GpuBuffer<unsigned int> regions;
+  auto magnet = mWorld.addFerromagnet(mGrid, geometry, regions, ferromagnet_name);
 
   magnet->enableDemag = false;
   magnet->msat.set(Ms);

--- a/src/cmd/standard_problem4.cpp
+++ b/src/cmd/standard_problem4.cpp
@@ -22,7 +22,9 @@ void standard_problem4() {
 
   MumaxWorld mWorld(cellsize);
   Grid mGrid(n);
-  auto magnet = mWorld.addFerromagnet(mGrid, 3, ferromagnet_name);
+  GpuBuffer<bool> geometry;
+  GpuBuffer<unsigned int> regions;
+  auto magnet = mWorld.addFerromagnet(mGrid, geometry, regions, ferromagnet_name);
 
   magnet->msat.set(800E3);
   magnet->aex.set(13E-12);


### PR DESCRIPTION
This PR fixes the `cmd` executable (allows for easy C++/CUDA debugging). The executables are installed inside the activated conda environment when using `pip` to compile `mumaxplus`.

It might be possible that a clean cache/build is necessary. In order to do this, run
```
pip uninstall -y mumaxplus
rm -rf build dist *.egg-info
pip install .
```
Then, the executable can be run by executing
```
cmd
```