### PR TITLE
Feature/frozenspins

### DIFF
--- a/mumaxplus/ferromagnet.py
+++ b/mumaxplus/ferromagnet.py
@@ -597,6 +597,15 @@ class Ferromagnet(Magnet):
     def amr_ratio(self, value):
         self.amr_ratio.set(value)
 
+    @property
+    def frozen_spins(self):
+        """Defines spins that should be fixed."""
+        return Parameter(self._impl.frozen_spins)
+    
+    @frozen_spins.setter
+    def frozen_spins(self, value):
+        self.frozen_spins.set(value)
+
     # --- magnetoelasticity ---
 
     @property

--- a/mumaxplus/ferromagnet.py
+++ b/mumaxplus/ferromagnet.py
@@ -599,7 +599,8 @@ class Ferromagnet(Magnet):
 
     @property
     def frozen_spins(self):
-        """Defines spins that should be fixed."""
+        """Defines spins that should be fixed by setting torque to (0, 0, 0)
+        wherever frozen_spins is not 0."""
         return Parameter(self._impl.frozen_spins)
     
     @frozen_spins.setter

--- a/src/bindings/wrap_ferromagnet.cpp
+++ b/src/bindings/wrap_ferromagnet.cpp
@@ -63,6 +63,7 @@ void wrap_ferromagnet(py::module& m) {
       .def_readonly("applied_potential", &Ferromagnet::appliedPotential)
       .def_readonly("conductivity", &Ferromagnet::conductivity)
       .def_readonly("amr_ratio", &Ferromagnet::amrRatio)
+      .def_readonly("frozen_spins", &Ferromagnet::frozenSpins)
       .def_readwrite("RelaxTorqueThreshold", &Ferromagnet::RelaxTorqueThreshold)
       .def_readonly("poisson_system", &Ferromagnet::poissonSystem)
       .def_readonly("B1", &Ferromagnet::B1)

--- a/src/physics/ferromagnet.cpp
+++ b/src/physics/ferromagnet.cpp
@@ -53,6 +53,7 @@ Ferromagnet::Ferromagnet(std::shared_ptr<System> system_ptr,
       appliedPotential(system(), std::nanf("0"), name + ":applied_potential", "V"),
       conductivity(system(), 0.0, name + ":conductivity", "S/m"),
       amrRatio(system(), 0.0, name + ":amr_ratio", ""),
+      frozenSpins(system(), 0.0, name + ":frozen_spins", ""),
       RelaxTorqueThreshold(-1.0),
       poissonSystem(this), 
       // magnetoelasticity

--- a/src/physics/ferromagnet.hpp
+++ b/src/physics/ferromagnet.hpp
@@ -86,6 +86,7 @@ class Ferromagnet : public Magnet {
   Parameter appliedPotential;
   Parameter conductivity;
   Parameter amrRatio;
+  Parameter frozenSpins;
   real RelaxTorqueThreshold;
   
   curandGenerator_t randomGenerator;

--- a/src/physics/torque.cu
+++ b/src/physics/torque.cu
@@ -63,7 +63,8 @@ __global__ void k_freezespins(CuField torque,
     return;
   }
 
-  torque.setVectorInCell(idx, torque.vectorAt(idx) * (1 - frozenSpins.valueAt(idx)));
+  if (frozenSpins.valueAt(idx) != 0)
+    torque.setVectorInCell(idx, real3{0., 0., 0.});
 }
 
 void freezeSpins(Field &torque, const Parameter &frozenSpins) {

--- a/src/physics/torque.hpp
+++ b/src/physics/torque.hpp
@@ -6,8 +6,6 @@
 class Ferromagnet;
 class Field;
 
-void freezeSpins(Field&, const Parameter&);
-
 Field evalTorque(const Ferromagnet*);
 Field evalLlgTorque(const Ferromagnet*);
 Field evalRelaxTorque(const Ferromagnet*);

--- a/src/physics/torque.hpp
+++ b/src/physics/torque.hpp
@@ -6,6 +6,8 @@
 class Ferromagnet;
 class Field;
 
+void freezeSpins(Field&, const Parameter&);
+
 Field evalTorque(const Ferromagnet*);
 Field evalLlgTorque(const Ferromagnet*);
 Field evalRelaxTorque(const Ferromagnet*);

--- a/test/test_frozenspins.py
+++ b/test/test_frozenspins.py
@@ -1,0 +1,51 @@
+from mumaxplus import Grid, World, Ferromagnet
+
+def expectv(result, wanted, tol):
+    for i in range(3):
+        assert abs(result[i] - wanted[i]) < tol
+
+def test_frozenspins():
+    """Based on standard problem 4, but all spins are fixed, so there should be no dynamics."""
+
+    world = World((500e-9/128, 125e-9/32, 3e-9/2))
+    magnet = Ferromagnet(world, Grid((128, 32, 2)))
+
+    magnet.msat = 800e3
+    magnet.aex = 13e-12
+    magnet.bias_magnetic_field = (-24.6E-3, 4.3E-3, 0)
+    magnet.frozen_spins = 1
+    magnet.magnetization = (1, .1, 0)
+    
+    avg0 = magnet.magnetization.average()
+
+    world.timesolver.run(1e-9)
+
+    expectv(magnet.magnetization.average(), avg0, 1e-7)
+
+
+def test_frozenspins_inhomogeneous():
+    """Frozen spins in half the geometry."""
+    world = World((500e-9/128, 125e-9/32, 3e-9/2))
+    magnet = Ferromagnet(world, Grid((128, 32, 2)))
+
+    magnet.msat = 800e3
+    magnet.aex = 13e-12
+    magnet.alpha = 0.02
+    magnet.frozen_spins = 1
+    magnet.magnetization = (1, .1, 0)
+
+    # freeze right half
+    center_x = magnet.center[0]
+    magnet.frozen_spins = lambda x, y, z: 1 if x > center_x else 0
+
+    magnet.magnetization = (1, .1, 0)
+
+    # minimize
+    magnet.minimize()
+    tol = 1e-6
+    expectv(magnet.magnetization.average(), (0.9809795618057251, 0.11742201447486877, 0), tol)
+
+    # reversal
+    magnet.bias_magnetic_field = (-24.6E-3, 4.3E-3, 0)
+    world.timesolver.run(1e-9)
+    expectv(magnet.magnetization.average(), [0.14499470591545105, 0.24905619025230408, 0.0021978835575282574], tol)

--- a/test/test_frozenspins.py
+++ b/test/test_frozenspins.py
@@ -12,6 +12,7 @@ def test_frozenspins():
 
     magnet.msat = 800e3
     magnet.aex = 13e-12
+    magnet.alpha = 0.02
     magnet.bias_magnetic_field = (-24.6E-3, 4.3E-3, 0)
     magnet.frozen_spins = 1
     magnet.magnetization = (1, .1, 0)
@@ -24,14 +25,15 @@ def test_frozenspins():
 
 
 def test_frozenspins_inhomogeneous():
-    """Frozen spins in half the geometry."""
+    """Frozen spins in half the geometry.
+    Compare to vectors to make sure the behaviour did not change as of writing this test.
+    """
     world = World((500e-9/128, 125e-9/32, 3e-9/2))
     magnet = Ferromagnet(world, Grid((128, 32, 2)))
 
     magnet.msat = 800e3
     magnet.aex = 13e-12
     magnet.alpha = 0.02
-    magnet.frozen_spins = 1
     magnet.magnetization = (1, .1, 0)
 
     # freeze right half
@@ -48,4 +50,4 @@ def test_frozenspins_inhomogeneous():
     # reversal
     magnet.bias_magnetic_field = (-24.6E-3, 4.3E-3, 0)
     world.timesolver.run(1e-9)
-    expectv(magnet.magnetization.average(), [0.14499470591545105, 0.24905619025230408, 0.0021978835575282574], tol)
+    expectv(magnet.magnetization.average(), (0.14499470591545105, 0.24905619025230408, 0.0021978835575282574), tol)


### PR DESCRIPTION
Add `frozen_spins` parameter like in mumax³. This can be useful for setting custom fixed boundary conditions. It works by setting the calculated torque to (0, 0, 0) if frozenspins is not 0 there.