### PR TITLE
Add magnetic force microscopy

### DIFF
--- a/mumaxplus/antiferromagnet.py
+++ b/mumaxplus/antiferromagnet.py
@@ -405,3 +405,7 @@ class Antiferromagnet(Magnet):
         enable_elastodynamics, elastic_energy, kinetic_energy
         """
         return ScalarQuantity(_cpp.total_energy(self._impl))
+
+    @property
+    def mfm(self):
+        return FieldQuantity(_cpp.mfm(self._impl))

--- a/mumaxplus/antiferromagnet.py
+++ b/mumaxplus/antiferromagnet.py
@@ -408,4 +408,9 @@ class Antiferromagnet(Magnet):
 
     @property
     def mfm(self):
+        """Magnetic force microscopy.
+        This returns the potential energy (in Joules) of a tip with two monopole
+        charges of +-1/µ0 feels when hovering over the magnet. This can then be
+        used to create an MFM image of the antiferromagnet.
+        """
         return FieldQuantity(_cpp.mfm(self._impl))

--- a/mumaxplus/ferromagnet.py
+++ b/mumaxplus/ferromagnet.py
@@ -1073,3 +1073,7 @@ class Ferromagnet(Magnet):
         effective_body_force, magnetoelastic_field
         """
         return FieldQuantity(_cpp.magnetoelastic_force(self._impl))
+    
+    @property
+    def mfm(self):
+        return FieldQuantity(_cpp.mfm(self._impl))

--- a/mumaxplus/ferromagnet.py
+++ b/mumaxplus/ferromagnet.py
@@ -1076,4 +1076,9 @@ class Ferromagnet(Magnet):
     
     @property
     def mfm(self):
+        """Magnetic force microscopy.
+        This returns the potential energy (in Joules) of a tip with two monopole
+        charges of +-1/µ0 feels when hovering over the magnet. This can then be
+        used to create an MFM image of the ferromagnet.
+        """
         return FieldQuantity(_cpp.mfm(self._impl))

--- a/mumaxplus/magnet.py
+++ b/mumaxplus/magnet.py
@@ -554,10 +554,11 @@ class Magnet(ABC):
         return StrayField._from_impl(
                         self._impl.stray_field_from_magnet(source_magnet._impl))
     
-    # --- MFM ---
+    # --- Magnetic force microscopy ---
     @property
     def lift(self):
-        """The hight of the MFM tip above the sample
+        """The height (in meters) of the MFM tip above the xy-surface
+        of the sample. (Default = 10e-9 m)
         
         See Also
         --------
@@ -572,15 +573,16 @@ class Magnet(ABC):
         warn = False
         if self.lift.is_uniform:
             warn = self.lift.uniform_value < 0
-        elif _np.any(self.lift.eval() < 0):
+        elif _np.any(self.lift.eval() < 1e-9):
             warn = True
         
         if warn:
-            warnings.warn("The tip will scratch your sample, lift before it is too late!")
+            warnings.warn("The tip will scratch your sample, increase lift above 1 nm before it is too late!")
         
     @property
     def tipsize(self):
-        """The distance between the two magnetic monopoles in the tip
+        """The distance (in meters) between the two magnetic monopoles in the tip.
+        The tip is perpendicular to the xy-surface of the sample. (default = 1e-3 m)
         
         See Also
         --------

--- a/mumaxplus/magnet.py
+++ b/mumaxplus/magnet.py
@@ -12,6 +12,8 @@ from .scalarquantity import ScalarQuantity
 from .strayfield import StrayField
 from .variable import Variable
 
+import warnings
+
 class Magnet(ABC):
     """A Magnet should never be initialized by the user. It contains no physics.
     Use ``Ferromagnet`` or ``Antiferromagnet`` instead.
@@ -551,3 +553,41 @@ class Magnet(ABC):
         """
         return StrayField._from_impl(
                         self._impl.stray_field_from_magnet(source_magnet._impl))
+    
+    # --- MFM ---
+    @property
+    def lift(self):
+        """The hight of the MFM tip above the sample
+        
+        See Also
+        --------
+        tipsize
+        """
+        return Parameter(self._impl.lift)
+
+    @lift.setter
+    def lift(self, value):
+        self.lift.set(value)
+
+        warn = False
+        if self.lift.is_uniform:
+            warn = self.lift.uniform_value < 0
+        elif _np.any(self.lift.eval() < 0):
+            warn = True
+        
+        if warn:
+            warnings.warn("The tip will scratch your sample, lift before it is too late!")
+        
+    @property
+    def tipsize(self):
+        """The distance between the two magnetic monopoles in the tip
+        
+        See Also
+        --------
+        lift
+        """
+        return Parameter(self._impl.lift)
+
+    @tipsize.setter
+    def tipsize(self, value):
+        self.tipsize.set(value)

--- a/src/bindings/wrap_antiferromagnet.cpp
+++ b/src/bindings/wrap_antiferromagnet.cpp
@@ -45,5 +45,6 @@ void wrap_antiferromagnet(py::module& m) {
   m.def("total_energy",
         py::overload_cast<const Antiferromagnet*>(&totalEnergyQuantity));
 
-  m.def("mfm", &magneticForceMicroscopyAFMQuantity);
+  m.def("mfm",
+        py::overload_cast<const Antiferromagnet*>(&magneticForceMicroscopyQuantity));
 }

--- a/src/bindings/wrap_antiferromagnet.cpp
+++ b/src/bindings/wrap_antiferromagnet.cpp
@@ -8,6 +8,7 @@
 #include "fieldquantity.hpp"
 #include "magnet.hpp"
 #include "mumaxworld.hpp"
+#include "mfm.hpp"
 #include "neel.hpp"
 #include "parameter.hpp"
 #include "fullmag.hpp"
@@ -43,4 +44,6 @@ void wrap_antiferromagnet(py::module& m) {
         py::overload_cast<const Antiferromagnet*>(&totalEnergyDensityQuantity));
   m.def("total_energy",
         py::overload_cast<const Antiferromagnet*>(&totalEnergyQuantity));
+
+  m.def("mfm", &magneticForceMicroscopyAFMQuantity);
 }

--- a/src/bindings/wrap_ferromagnet.cpp
+++ b/src/bindings/wrap_ferromagnet.cpp
@@ -125,9 +125,8 @@ void wrap_ferromagnet(py::module& m) {
   m.def("magnetoelastic_field", &magnetoelasticFieldQuantity);
   m.def("magnetoelastic_energy_density", &magnetoelasticEnergyDensityQuantity);
   m.def("magnetoelastic_energy", &magnetoelasticEnergyQuantity);
-
   m.def("magnetoelastic_force", &magnetoelasticForceQuantity);
 
-  // mfm
-  m.def("mfm", &magneticForceMicroscopyQuantity);
+  m.def("mfm",
+        py::overload_cast<const Ferromagnet*>(&magneticForceMicroscopyQuantity));
 }

--- a/src/bindings/wrap_ferromagnet.cpp
+++ b/src/bindings/wrap_ferromagnet.cpp
@@ -16,6 +16,7 @@
 #include "magnet.hpp"
 #include "magnetoelasticfield.hpp"
 #include "magnetoelasticforce.hpp"
+#include "mfm.hpp"
 #include "mumaxworld.hpp"
 #include "parameter.hpp"
 #include "stt.hpp"
@@ -126,4 +127,7 @@ void wrap_ferromagnet(py::module& m) {
   m.def("magnetoelastic_energy", &magnetoelasticEnergyQuantity);
 
   m.def("magnetoelastic_force", &magnetoelasticForceQuantity);
+
+  // mfm
+  m.def("mfm", &magneticForceMicroscopyQuantity);
 }

--- a/src/bindings/wrap_magnet.cpp
+++ b/src/bindings/wrap_magnet.cpp
@@ -42,6 +42,10 @@ void wrap_magnet(py::module& m) {
       .def_readonly("rigid_norm_strain", &Magnet::rigidNormStrain)
       .def_readonly("rigid_shear_strain", &Magnet::rigidShearStrain)
 
+      // MFM
+      .def_readonly("lift", &Ferromagnet::lift)
+      .def_readonly("tipsize", &Ferromagnet::tipsize)
+
       .def("stray_field_from_magnet",
           [](const Magnet* m, Magnet* magnet) {
             const StrayField* strayField = m->getStrayField(magnet);

--- a/src/physics/CMakeLists.txt
+++ b/src/physics/CMakeLists.txt
@@ -42,6 +42,8 @@ add_library(physics STATIC
     magnetoelasticfield.hpp
     magnetoelasticforce.cu
     magnetoelasticforce.hpp
+    mfm.cu
+    mfm.hpp
     minimizer.cu
     minimizer.hpp
     mumaxworld.cpp

--- a/src/physics/magnet.cpp
+++ b/src/physics/magnet.cpp
@@ -31,7 +31,10 @@ Magnet::Magnet(std::shared_ptr<System> system_ptr,
       eta(system(), 0.0, name + ":eta", "kg/m3s"),
       rho(system(), 1.0, name + ":rho", "kg/m3"),
       rigidNormStrain(system(), {0.0, 0.0, 0.0}, name + ":rigid_norm_strain", ""),
-      rigidShearStrain(system(), {0.0, 0.0, 0.0}, name + ":rigid_shear_strain", "") {
+      rigidShearStrain(system(), {0.0, 0.0, 0.0}, name + ":rigid_shear_strain", ""),
+      // mfm
+      lift(system(), 10e-9, name + ":lift", "m"),
+      tipsize(system(), 1e-3, name + ":tipsize", "m") {
   // Check that the system has at least size 1
   int3 size = system_->grid().size();
   if (size.x < 1 || size.y < 1 || size.z < 1)
@@ -54,7 +57,8 @@ Magnet::Magnet(Magnet&& other) noexcept
       externalBodyForce(other.externalBodyForce),
       C11(other.C11), C12(other.C12), C44(other.C44),
       eta(other.eta), rho(other.rho), rigidNormStrain(other.rigidNormStrain),
-      rigidShearStrain(other.rigidShearStrain) {
+      rigidShearStrain(other.rigidShearStrain), lift(other.lift),
+      tipsize(other.tipsize) {
   other.system_ = nullptr;
   other.name_ = "";
 }

--- a/src/physics/magnet.hpp
+++ b/src/physics/magnet.hpp
@@ -84,6 +84,10 @@ class Magnet {
   Parameter eta;  // Phenomenological elastic damping constant
   Parameter rho;  // Mass density
 
+  // Magnetoelasticity
+  Parameter lift;     // The hight of the MFM tip above the sample
+  Parameter tipsize;  // The distance between the 2 magnetic monopolese in the tip
+
 
   // Delete copy constructor and copy assignment operator to prevent shallow copies
   Magnet(const Magnet&) = delete;

--- a/src/physics/magnet.hpp
+++ b/src/physics/magnet.hpp
@@ -84,8 +84,8 @@ class Magnet {
   Parameter eta;  // Phenomenological elastic damping constant
   Parameter rho;  // Mass density
 
-  // Magnetoelasticity
-  Parameter lift;     // The hight of the MFM tip above the sample
+  // mfm
+  Parameter lift;     // The height of the MFM tip above the sample
   Parameter tipsize;  // The distance between the 2 magnetic monopolese in the tip
 
 

--- a/src/physics/mfm.cu
+++ b/src/physics/mfm.cu
@@ -1,0 +1,120 @@
+#include "constants.hpp"
+#include "cudalaunch.hpp"
+#include "fullmag.hpp"
+#include "mfm.hpp"
+
+/** This code calculates an MFM kernel
+  * Need to calculate dF/dz = sum M . d²B/dz²
+  * The sum runs over each cell in a magnet.
+  * M is the magnetization in that cell.
+  * B is the stray field from the tip evaluated in the cell.
+  * Source: The design and verification of MuMax3.
+  */
+__global__ void k_magneticForceMicroscopy(CuField kernel, CuField magnetization,
+                                          const Grid mastergrid, const int3 pbcRepetitions,
+                                          CuParameter lift, CuParameter tipsize) {
+
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (!kernel.cellInGrid(idx))
+        return;
+    
+    // The cell-coordinate of the tip (without lift)
+    const real3 cellsize = kernel.system.cellsize;
+    int3 coo = kernel.system.grid.index2coord(idx);
+    real x0 = coo.x * cellsize.x;
+    real y0 = coo.y * cellsize.y;
+    real z0 = coo.z * cellsize.z;
+
+    real tipCharge = 1/MU0;  // charge at the tip
+    real delta = 1e-9;       // tip oscillation, take 2nd derivative over this distance
+    real V = cellsize.x * cellsize.y * cellsize.z;  // volume of a cell
+    real pi = 3.1415926535897931f;
+
+    // Size of the grid
+    int xmax = kernel.system.grid.size().x;
+    int ymax = kernel.system.grid.size().y;
+    int zmax = kernel.system.grid.size().z;
+
+    real dFdz = 0.;
+
+    // Loop over pbc
+    for (int Nx = -pbcRepetitions.x; Nx <= pbcRepetitions.x; Nx++) {
+        real xpbc = Nx * mastergrid.size().x;
+        for (int Ny = -pbcRepetitions.y; Ny <= pbcRepetitions.y; Ny++) {
+            real ypbc = Ny * mastergrid.size().y;
+            for (int Nz = -pbcRepetitions.z; Nz <= pbcRepetitions.z; Nz++) {
+                real zpbc = Nz * mastergrid.size().z;
+
+                // Loop over cells in the magnet
+                for (int iz = 0; iz < zmax; iz++) {
+                    real z = (iz+zpbc) * cellsize.z;
+                    for (int iy = 0; iy < ymax; iy++) {
+                        real y = (iy+ypbc) * cellsize.y;
+                        for (int ix = 0; ix < xmax; ix++) {
+                            real x = (ix+xpbc) * cellsize.x;
+
+                            real3 m = magnetization.vectorAt(int3{ix, iy, iz});
+                            real E[3];  // Energy of 3 tip positions
+
+                            // Get 3 different tip heights
+                            for (int i = -1; i <= 1; i++) {
+                                // First pole position and field
+                                real3 R = {x0-x,
+                                           y0-y,
+                                           z0 + z - (lift.valueAt(idx) + i*delta)};
+                                real r = sqrt(R.x*R.x + R.y*R.y + R.z*R.z);
+                                real3 B = R * tipCharge/(4*pi*r*r*r);
+                                
+                                // Second pole position and field
+                                R.z = z0 + z - (lift.valueAt(idx) + tipsize.valueAt(idx) + i*delta);
+                                r = sqrt(R.x*R.x + R.y*R.y + R.z*R.z);
+                                B.x -= R.x * tipCharge/(4*pi*r*r*r);
+                                B.y -= R.y * tipCharge/(4*pi*r*r*r);
+                                B.z -= R.z * tipCharge/(4*pi*r*r*r);
+                                
+                                // Energy (B.M) * V
+                                E[i+1] = (B.x * m.x + B.y * m.y + B.z * m.z) * V;
+                            }
+
+                            // dF/dz = d²E/dz²
+                            dFdz += ((E[0] - E[1]) + (E[2] - E[1])) / (delta*delta);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    kernel.setValueInCell(idx, 0, dFdz);
+}
+
+Field evalMagneticForceMicroscopy(const Ferromagnet* magnet) {
+    Field mfm(magnet->system(), 1, 0.0);
+    const CuField magnetization = fullMagnetizationQuantity(magnet).eval().cu();
+    Grid mastergrid = magnet->world()->mastergrid();
+    int3 pbcRepetitions = magnet->world()->pbcRepetitions();
+    CuParameter lift = magnet->lift.cu();
+    CuParameter tipsize = magnet->tipsize.cu();
+    int ncells = mfm.grid().ncells();
+    cudaLaunch(ncells, k_magneticForceMicroscopy, mfm.cu(), magnetization, mastergrid, pbcRepetitions, lift, tipsize);
+    return mfm;
+}
+
+Field evalMagneticForceMicroscopyAFM(const Antiferromagnet* magnet) {
+    Field mfm(magnet->system(), 1, 0.0);
+    const CuField magnetization = fullMagnetizationQuantity(magnet).eval().cu();
+    Grid mastergrid = magnet->world()->mastergrid();
+    int3 pbcRepetitions = magnet->world()->pbcRepetitions();
+    CuParameter lift = magnet->lift.cu();
+    CuParameter tipsize = magnet->tipsize.cu();
+    int ncells = mfm.grid().ncells();
+    cudaLaunch(ncells, k_magneticForceMicroscopy, mfm.cu(), magnetization, mastergrid, pbcRepetitions, lift, tipsize);
+    return mfm;
+}
+
+FM_FieldQuantity magneticForceMicroscopyQuantity(const Ferromagnet* magnet) {
+    return FM_FieldQuantity(magnet, evalMagneticForceMicroscopy, 1, "magnetic_force_microscopy", "J");
+}
+
+AFM_FieldQuantity magneticForceMicroscopyAFMQuantity(const Antiferromagnet* magnet) {
+    return AFM_FieldQuantity(magnet, evalMagneticForceMicroscopyAFM, 1, "magnetic_force_microscopy", "J");
+}

--- a/src/physics/mfm.hpp
+++ b/src/physics/mfm.hpp
@@ -6,8 +6,7 @@ class Ferromagnet;
 class Antiferromagnet;
 class Field;
 
-Field evalMagneticForceMicroscopy(const Ferromagnet*);
-Field evalMagneticForceMicroscopyAFM(const Antiferromagnet*);
+Field evalMagneticForceMicroscopy(const Magnet*);
 
 FM_FieldQuantity magneticForceMicroscopyQuantity(const Ferromagnet*);
 AFM_FieldQuantity magneticForceMicroscopyQuantity(const Antiferromagnet*);

--- a/src/physics/mfm.hpp
+++ b/src/physics/mfm.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "quantityevaluator.hpp"
+
+class Ferromagnet;
+class Field;
+
+Field evalMagneticForceMicroscopy(const Ferromagnet*);
+Field evalMagneticForceMicroscopyAFM(const Antiferromagnet*);
+
+FM_FieldQuantity magneticForceMicroscopyQuantity(const Ferromagnet*);
+AFM_FieldQuantity magneticForceMicroscopyAFMQuantity(const Antiferromagnet*);

--- a/src/physics/mfm.hpp
+++ b/src/physics/mfm.hpp
@@ -3,10 +3,11 @@
 #include "quantityevaluator.hpp"
 
 class Ferromagnet;
+class Antiferromagnet;
 class Field;
 
 Field evalMagneticForceMicroscopy(const Ferromagnet*);
 Field evalMagneticForceMicroscopyAFM(const Antiferromagnet*);
 
 FM_FieldQuantity magneticForceMicroscopyQuantity(const Ferromagnet*);
-AFM_FieldQuantity magneticForceMicroscopyAFMQuantity(const Antiferromagnet*);
+AFM_FieldQuantity magneticForceMicroscopyQuantity(const Antiferromagnet*);


### PR DESCRIPTION
Now we are capable of creating MFM images for ferromagnets and antiferromagnets! The method is similar to the mumax³ method.
For the MFM kernel we need to calculate d**F**/dz = sum **M** . d²**B**/dz² for every tip position. The sum runs over each cell in the magnet, M is the total magnetization and B is the strayfield from the tip in a cell. The tip has been approximated as 2 monopoles with a charge of +- 1/µ0 and a distance settable by the user via `tipsize` (default 1e-3 m).
In this case the stray field can be calculated as **B** = +-**r** / (µ0 4 pi r³), where **r** is the distance between the pole and the cell.
In order to calculate d²B/dz², there is a `delta` parameter that is used to calculate the strayfield when the tip is at position (x,y,z-`delta`), (x,y,z) and (x,y,z+`delta`).
The height of the tip above the sample can also be set by a user by using the `lift` parameter (default 10e-9).

