### PR TITLE
Fix issue #75

### DIFF
--- a/mumaxplus/ferromagnet.py
+++ b/mumaxplus/ferromagnet.py
@@ -11,7 +11,6 @@ from .interparameter import InterParameter
 from .parameter import Parameter
 from .poissonsystem import PoissonSystem
 from .scalarquantity import ScalarQuantity
-from .strayfield import StrayField
 from .variable import Variable
 
 import warnings
@@ -706,16 +705,6 @@ class Ferromagnet(Magnet):
         """The maximum value of the torque over all cells (rad/s)."""
         return ScalarQuantity(_cpp.max_torque(self._impl))
     
-    @property
-    def demag_field(self):
-        """Demagnetization field (T).
-        
-        See Also
-        --------
-        demag_energy_density, demage_energy
-        """
-        return StrayField._from_impl(self._impl.stray_field_from_magnet(self._impl))
-
     @property
     def demag_energy_density(self):
         """Energy density related to the demag field (J/m³).

--- a/mumaxplus/ferromagnet.py
+++ b/mumaxplus/ferromagnet.py
@@ -11,6 +11,7 @@ from .interparameter import InterParameter
 from .parameter import Parameter
 from .poissonsystem import PoissonSystem
 from .scalarquantity import ScalarQuantity
+from .strayfield import StrayField
 from .variable import Variable
 
 import warnings
@@ -713,7 +714,7 @@ class Ferromagnet(Magnet):
         --------
         demag_energy_density, demage_energy
         """
-        return FieldQuantity(_cpp.demag_field(self._impl))
+        return StrayField._from_impl(self._impl.stray_field_from_magnet(self._impl))
 
     @property
     def demag_energy_density(self):

--- a/mumaxplus/magnet.py
+++ b/mumaxplus/magnet.py
@@ -551,3 +551,16 @@ class Magnet(ABC):
         """
         return StrayField._from_impl(
                         self._impl.stray_field_from_magnet(source_magnet._impl))
+
+    @property
+    def demag_field(self):
+        """Demagnetization field (T).
+
+        Ferromagnetic sublattices of other host magnets don't have a demag field.
+        
+        See Also
+        --------
+        stray_field_from_magnet
+        StrayField
+        """
+        return self.stray_field_from_magnet(self)

--- a/src/bindings/wrap_ferromagnet.cpp
+++ b/src/bindings/wrap_ferromagnet.cpp
@@ -78,7 +78,6 @@ void wrap_ferromagnet(py::module& m) {
   m.def("spin_transfer_torque", &spinTransferTorqueQuantity);
   m.def("max_torque", &maxTorqueQuantity);
 
-  m.def("demag_field", &demagFieldQuantity);
   m.def("demag_energy_density", &demagEnergyDensityQuantity);
   m.def("demag_energy", &demagEnergyQuantity);
 

--- a/src/physics/demag.cpp
+++ b/src/physics/demag.cpp
@@ -33,10 +33,6 @@ real evalDemagEnergy(const Ferromagnet* magnet) {
   return ncells * edensAverage * cellVolume;
 }
 
-FM_FieldQuantity demagFieldQuantity(const Ferromagnet* magnet) {
-  return FM_FieldQuantity(magnet, evalDemagField, 3, "demag_field", "T");
-}
-
 FM_FieldQuantity demagEnergyDensityQuantity(const Ferromagnet* magnet) {
   return FM_FieldQuantity(magnet, evalDemagEnergyDensity, 1,
                           "demag_energy_density", "J/m3");

--- a/src/physics/demag.hpp
+++ b/src/physics/demag.hpp
@@ -12,6 +12,5 @@ Field evalDemagField(const Ferromagnet*);
 Field evalDemagEnergyDensity(const Ferromagnet*);
 real evalDemagEnergy(const Ferromagnet*);
 
-FM_FieldQuantity demagFieldQuantity(const Ferromagnet*);
 FM_FieldQuantity demagEnergyDensityQuantity(const Ferromagnet*);
 FM_ScalarQuantity demagEnergyQuantity(const Ferromagnet*);


### PR DESCRIPTION
Since `StrayField` inherits from `FieldQuantity`, this was an easy fix. The `StrayField` methods of a `Magnet`'s `stray_field` were already accessible.