### PR TITLE
Avoid crash when torque is zero

### DIFF
--- a/mumaxplus/timesolver.py
+++ b/mumaxplus/timesolver.py
@@ -190,7 +190,7 @@ class TimeSolver:
 
         See Also
         --------
-        headroom, lower_bound, sensible_factor, upper_bound
+        headroom, lower_bound, sensible_factor, sensible_timestep, upper_bound
         """
 
         return self._impl.max_error
@@ -208,7 +208,7 @@ class TimeSolver:
 
         See Also
         --------
-        lower_bound, max_error, sensible_factor, upper_bound
+        lower_bound, max_error, sensible_factor, sensible_timestep, upper_bound
         """
         return self._impl.headroom
 
@@ -226,7 +226,7 @@ class TimeSolver:
 
         See Also
         --------
-        headroom, max_error, sensible_factor, upper_bound
+        headroom, max_error, sensible_factor, sensible_timestep, upper_bound
         """
         return self._impl.lower_bound
 
@@ -244,7 +244,7 @@ class TimeSolver:
 
         See Also
         --------
-        headroom, lower_bound, max_error, sensible_factor
+        headroom, lower_bound, max_error, sensible_factor, sensible_timestep
         """
         return self._impl.upper_bound
 
@@ -262,7 +262,7 @@ class TimeSolver:
 
         See Also
         --------
-        headroom, lower_bound, max_error, upper_bound
+        headroom, lower_bound, max_error, sensible_timestep, upper_bound
         """
         return self._impl.sensible_factor
 
@@ -270,3 +270,21 @@ class TimeSolver:
     def sensible_factor(self, fact):
         assert fact > 0, "The sensible factor should be bigger than 0."
         self._impl.sensible_factor = fact
+
+    @property
+    def sensible_timestep(self):
+        """Return the time step which is used if no sensible time step
+        can be calculated (e.g. when the total torque is zero).
+
+        The default value is 1e-14 s.
+
+        See Also
+        --------
+        headroom, lower_bound, max_error, upper_bound
+        """
+        return self._impl.sensible_timestep
+
+    @sensible_timestep.setter
+    def sensible_timestep(self, dt):
+        assert dt > 0, "The sensible timestep should be bigger than 0."
+        self._impl.sensible_timestep = dt

--- a/mumaxplus/timesolver.py
+++ b/mumaxplus/timesolver.py
@@ -190,7 +190,7 @@ class TimeSolver:
 
         See Also
         --------
-        headroom, lower_bound, sensible_factor, sensible_timestep, upper_bound
+        headroom, lower_bound, sensible_factor, sensible_timestep_default, upper_bound
         """
 
         return self._impl.max_error
@@ -208,7 +208,7 @@ class TimeSolver:
 
         See Also
         --------
-        lower_bound, max_error, sensible_factor, sensible_timestep, upper_bound
+        lower_bound, max_error, sensible_factor, sensible_timestep_default, upper_bound
         """
         return self._impl.headroom
 
@@ -226,7 +226,7 @@ class TimeSolver:
 
         See Also
         --------
-        headroom, max_error, sensible_factor, sensible_timestep, upper_bound
+        headroom, max_error, sensible_factor, sensible_timestep_default, upper_bound
         """
         return self._impl.lower_bound
 
@@ -244,7 +244,7 @@ class TimeSolver:
 
         See Also
         --------
-        headroom, lower_bound, max_error, sensible_factor, sensible_timestep
+        headroom, lower_bound, max_error, sensible_factor, sensible_timestep_default
         """
         return self._impl.upper_bound
 
@@ -262,7 +262,7 @@ class TimeSolver:
 
         See Also
         --------
-        headroom, lower_bound, max_error, sensible_timestep, upper_bound
+        headroom, lower_bound, max_error, sensible_timestep_default, upper_bound
         """
         return self._impl.sensible_factor
 

--- a/mumaxplus/timesolver.py
+++ b/mumaxplus/timesolver.py
@@ -272,7 +272,7 @@ class TimeSolver:
         self._impl.sensible_factor = fact
 
     @property
-    def sensible_timestep(self):
+    def sensible_timestep_default(self):
         """Return the time step which is used if no sensible time step
         can be calculated (e.g. when the total torque is zero).
 
@@ -282,9 +282,8 @@ class TimeSolver:
         --------
         headroom, lower_bound, max_error, upper_bound
         """
-        return self._impl.sensible_timestep
+        return self._impl.sensible_timestep_default
 
-    @sensible_timestep.setter
-    def sensible_timestep(self, dt):
-        assert dt > 0, "The sensible timestep should be bigger than 0."
-        self._impl.sensible_timestep = dt
+    @sensible_timestep_default.setter
+    def sensible_timestep_default(self, dt):
+        self._impl.sensible_timestep_default = dt

--- a/src/bindings/wrap_timesolver.cpp
+++ b/src/bindings/wrap_timesolver.cpp
@@ -25,7 +25,8 @@ void wrap_timesolver(py::module& m) {
       .def_property("lower_bound", &TimeSolver::lowerBound, &TimeSolver::setLowerBound)
       .def_property("max_error", &TimeSolver::maxError, &TimeSolver::setMaxError)
       .def_property("sensible_factor", &TimeSolver::sensibleFactor, &TimeSolver::setSensibleFactor)
-      .def_property("sensible_timestep", &TimeSolver::sensibleTimestep, &TimeSolver::setSensibleTimestep)
+      .def_property("sensible_timestep_default", &TimeSolver::sensibleTimestep,
+                                                 &TimeSolver::setSensibleTimestep)
       .def_property("upper_bound", &TimeSolver::upperBound, &TimeSolver::setUpperBound)
       .def("step", &TimeSolver::step)
       .def("steps", &TimeSolver::steps)

--- a/src/bindings/wrap_timesolver.cpp
+++ b/src/bindings/wrap_timesolver.cpp
@@ -25,8 +25,8 @@ void wrap_timesolver(py::module& m) {
       .def_property("lower_bound", &TimeSolver::lowerBound, &TimeSolver::setLowerBound)
       .def_property("max_error", &TimeSolver::maxError, &TimeSolver::setMaxError)
       .def_property("sensible_factor", &TimeSolver::sensibleFactor, &TimeSolver::setSensibleFactor)
-      .def_property("sensible_timestep_default", &TimeSolver::sensibleTimestep,
-                                                 &TimeSolver::setSensibleTimestep)
+      .def_property("sensible_timestep_default", &TimeSolver::sensibleTimestepDefault,
+                                                 &TimeSolver::setSensibleTimestepDefault)
       .def_property("upper_bound", &TimeSolver::upperBound, &TimeSolver::setUpperBound)
       .def("step", &TimeSolver::step)
       .def("steps", &TimeSolver::steps)

--- a/src/bindings/wrap_timesolver.cpp
+++ b/src/bindings/wrap_timesolver.cpp
@@ -25,6 +25,7 @@ void wrap_timesolver(py::module& m) {
       .def_property("lower_bound", &TimeSolver::lowerBound, &TimeSolver::setLowerBound)
       .def_property("max_error", &TimeSolver::maxError, &TimeSolver::setMaxError)
       .def_property("sensible_factor", &TimeSolver::sensibleFactor, &TimeSolver::setSensibleFactor)
+      .def_property("sensible_timestep", &TimeSolver::sensibleTimestep, &TimeSolver::setSensibleTimestep)
       .def_property("upper_bound", &TimeSolver::upperBound, &TimeSolver::setUpperBound)
       .def("step", &TimeSolver::step)
       .def("steps", &TimeSolver::steps)

--- a/src/core/timesolver.cpp
+++ b/src/core/timesolver.cpp
@@ -41,10 +41,8 @@ real TimeSolver::sensibleTimeStep() const {
   for (auto eq : eqs_)
     if (real maxNorm = maxVecNorm(eq.rhs->eval()); maxNorm > globalMaxNorm)
       globalMaxNorm = maxNorm;
-  if (globalMaxNorm == 0) {
-    throw std::runtime_error("Timesolver cannot be executed since the right hand "
-                             "sides of all dynamic equations are zero.");
-  }
+  if (globalMaxNorm == 0) // Sensible timestep cannot be calculated if torque is zero
+    return sensibleTimestep_;
   return sensibleFactor_ / globalMaxNorm;
 }
 

--- a/src/core/timesolver.cpp
+++ b/src/core/timesolver.cpp
@@ -51,6 +51,12 @@ void TimeSolver::setEquations(std::vector<DynamicEquation> eqs) {
   if (!fixedTimeStep_) timestep_ = sensibleTimeStep();
 }
 
+void TimeSolver::setSensibleTimestep(real dt) {
+  if (dt > 0)
+    throw std::runtime_error("The sensible timestep should be larger than zero.");
+  sensibleTimestep_ = dt;
+}
+
 void TimeSolver::adaptTimeStep(real correctionFactor) {
   if (fixedTimeStep_)
     return;

--- a/src/core/timesolver.cpp
+++ b/src/core/timesolver.cpp
@@ -42,7 +42,7 @@ real TimeSolver::sensibleTimeStep() const {
     if (real maxNorm = maxVecNorm(eq.rhs->eval()); maxNorm > globalMaxNorm)
       globalMaxNorm = maxNorm;
   if (globalMaxNorm == 0) // Sensible timestep cannot be calculated if torque is zero
-    return sensibleTimestep_;
+    return sensibleTimestepDefault_;
   return sensibleFactor_ / globalMaxNorm;
 }
 
@@ -51,10 +51,10 @@ void TimeSolver::setEquations(std::vector<DynamicEquation> eqs) {
   if (!fixedTimeStep_) timestep_ = sensibleTimeStep();
 }
 
-void TimeSolver::setSensibleTimestep(real dt) {
-  if (dt > 0)
+void TimeSolver::setSensibleTimestepDefault(real dt) {
+  if (dt < 0)
     throw std::runtime_error("The sensible timestep should be larger than zero.");
-  sensibleTimestep_ = dt;
+  sensibleTimestepDefault_ = dt;
 }
 
 void TimeSolver::adaptTimeStep(real correctionFactor) {

--- a/src/core/timesolver.hpp
+++ b/src/core/timesolver.hpp
@@ -34,7 +34,7 @@ class TimeSolver {
   real lowerBound() const { return lowerBound_; }
   real maxError() const { return maxError_; }
   real sensibleFactor() const { return sensibleFactor_; }
-  real sensibleTimestep() const { return sensibleTimestep_; }
+  real sensibleTimestepDefault() const { return sensibleTimestepDefault_; }
   real time() const { return time_; }
   real timestep() const { return timestep_; }
   real upperBound() const { return upperBound_; }
@@ -49,7 +49,7 @@ class TimeSolver {
   void setLowerBound(real lowerBound) { lowerBound_ = lowerBound; }
   void setMaxError(real maxError) { maxError_ = maxError; }
   void setSensibleFactor(real factor) { sensibleFactor_ = factor; }
-  void setSensibleTimestep(real dt);
+  void setSensibleTimestepDefault(real dt);
   void setTime(real time) { time_ = time; }
   void setTimeStep(real dt) { timestep_ = dt; }
   void setUpperBound(real upperBound) { upperBound_ = upperBound; }
@@ -75,7 +75,7 @@ class TimeSolver {
   real lowerBound_ = 0.5;
   real maxError_ = 1e-5;
   real sensibleFactor_ = 0.01;
-  real sensibleTimestep_ = 1e-14;
+  real sensibleTimestepDefault_ = 1e-14;
   real time_ = 0.0;
   real timestep_ = 0.0;
   real upperBound_ = 2.0;

--- a/src/core/timesolver.hpp
+++ b/src/core/timesolver.hpp
@@ -34,6 +34,7 @@ class TimeSolver {
   real lowerBound() const { return lowerBound_; }
   real maxError() const { return maxError_; }
   real sensibleFactor() const { return sensibleFactor_; }
+  real sensibleTimestep() const { return sensibleTimestep_; }
   real time() const { return time_; }
   real timestep() const { return timestep_; }
   real upperBound() const { return upperBound_; }
@@ -48,6 +49,7 @@ class TimeSolver {
   void setLowerBound(real lowerBound) { lowerBound_ = lowerBound; }
   void setMaxError(real maxError) { maxError_ = maxError; }
   void setSensibleFactor(real factor) { sensibleFactor_ = factor; }
+  void setSensibleTimestep(real dt) { sensibleTimestep_ = dt; }
   void setTime(real time) { time_ = time; }
   void setTimeStep(real dt) { timestep_ = dt; }
   void setUpperBound(real upperBound) { upperBound_ = upperBound; }
@@ -73,6 +75,7 @@ class TimeSolver {
   real lowerBound_ = 0.5;
   real maxError_ = 1e-5;
   real sensibleFactor_ = 0.01;
+  real sensibleTimestep_ = 1e-14;
   real time_ = 0.0;
   real timestep_ = 0.0;
   real upperBound_ = 2.0;

--- a/src/core/timesolver.hpp
+++ b/src/core/timesolver.hpp
@@ -49,7 +49,7 @@ class TimeSolver {
   void setLowerBound(real lowerBound) { lowerBound_ = lowerBound; }
   void setMaxError(real maxError) { maxError_ = maxError; }
   void setSensibleFactor(real factor) { sensibleFactor_ = factor; }
-  void setSensibleTimestep(real dt) { sensibleTimestep_ = dt; }
+  void setSensibleTimestep(real dt);
   void setTime(real time) { time_ = time; }
   void setTimeStep(real dt) { timestep_ = dt; }
   void setUpperBound(real upperBound) { upperBound_ = upperBound; }

--- a/test/test_frozenspins.py
+++ b/test/test_frozenspins.py
@@ -19,9 +19,6 @@ def test_frozenspins():
     
     avg0 = magnet.magnetization.average()
 
-    # Adaptive timestepping is prohibitted when the total torque is zero
-    world.timesolver.adaptive_timestep = False
-    world.timesolver.timestep = 1e-12
     world.timesolver.run(1e-9)
 
     expectv(magnet.magnetization.average(), avg0, 1e-7)


### PR DESCRIPTION
The changes made in PR #74 are too drastic. The proposed changes omits a `runtime_error` by defining a default timestep which can be used when no sensible one can be calculated.