### PR TITLE
Add the ability to read and write ovf2 binary files

### DIFF
--- a/mumaxplus/fieldquantity.py
+++ b/mumaxplus/fieldquantity.py
@@ -118,4 +118,12 @@ class FieldQuantity:
         return (stop - start) / ntimes
     
     def write_ovf(self, file_name):
+        """Write the data to a .ovf file. It will be an ovf2 file containing
+        binary data. binary 4 if using SINGLE precision, binary 8 if using
+        DOUBLE precision.
+        
+        Parameters
+        ----------
+        file : string
+            the name of the output file."""
         self._impl.write_ovf(file_name)

--- a/mumaxplus/fieldquantity.py
+++ b/mumaxplus/fieldquantity.py
@@ -116,3 +116,6 @@ class FieldQuantity:
             self._impl.exec()
         stop = time.time()
         return (stop - start) / ntimes
+    
+    def write_ovf(self, file_name):
+        self._impl.write_ovf(file_name)

--- a/mumaxplus/parameter.py
+++ b/mumaxplus/parameter.py
@@ -212,3 +212,7 @@ class Parameter(FieldQuantity):
             self._impl.set((0, 0, 0))
 
         self.remove_time_terms()
+
+    def load_file(self, file):
+        """Use an .ovf file to create the parameter"""
+        self._impl.load_file(file)

--- a/mumaxplus/parameter.py
+++ b/mumaxplus/parameter.py
@@ -213,6 +213,6 @@ class Parameter(FieldQuantity):
 
         self.remove_time_terms()
 
-    def load_file(self, file):
+    def read_ovf(self, file):
         """Use an .ovf file to create the parameter"""
-        self._impl.load_file(file)
+        self._impl.read_ovf(file)

--- a/mumaxplus/parameter.py
+++ b/mumaxplus/parameter.py
@@ -214,5 +214,11 @@ class Parameter(FieldQuantity):
         self.remove_time_terms()
 
     def read_ovf(self, file):
-        """Use an .ovf file to create the parameter"""
+        """Use an .ovf file to create the parameter. It must be an ovf2 file
+        containing binary data.
+        
+        Parameters
+        ----------
+        file : string
+            the name of the input file."""
         self._impl.read_ovf(file)

--- a/mumaxplus/variable.py
+++ b/mumaxplus/variable.py
@@ -35,3 +35,7 @@ class Variable(FieldQuantity):
     def get(self):
         """Get the variable value."""
         return self._impl.get()
+    
+    def load_file(self, file):
+        """Use an .ovf file to create the variable"""
+        self._impl.load_file(file)

--- a/mumaxplus/variable.py
+++ b/mumaxplus/variable.py
@@ -36,6 +36,6 @@ class Variable(FieldQuantity):
         """Get the variable value."""
         return self._impl.get()
     
-    def load_file(self, file):
+    def read_ovf(self, file):
         """Use an .ovf file to create the variable"""
-        self._impl.load_file(file)
+        self._impl.read_ovf(file)

--- a/mumaxplus/variable.py
+++ b/mumaxplus/variable.py
@@ -37,5 +37,11 @@ class Variable(FieldQuantity):
         return self._impl.get()
     
     def read_ovf(self, file):
-        """Use an .ovf file to create the variable"""
+        """Use an .ovf file to create the variable. It must be an ovf2 file
+        containing binary data.
+        
+        Parameters
+        ----------
+        file : string
+            the name of the input file."""
         self._impl.read_ovf(file)

--- a/src/bindings/wrap_fieldquantity.cpp
+++ b/src/bindings/wrap_fieldquantity.cpp
@@ -12,6 +12,7 @@ void wrap_fieldquantity(py::module& m) {
       .def_property_readonly("ncomp", &FieldQuantity::ncomp)
       .def_property_readonly("grid", &FieldQuantity::grid)
       .def_property_readonly("system", &FieldQuantity::system)
+      .def("write_ovf", &FieldQuantity::writeOvf)
       .def("eval",
            [](const FieldQuantity* q) { return fieldToArray(q->eval()); })
       // exec does the same as eval but without returning the result (useful for

--- a/src/bindings/wrap_parameter.cpp
+++ b/src/bindings/wrap_parameter.cpp
@@ -37,7 +37,7 @@ void wrap_parameter(py::module& m) {
       .def("set_in_region", [](Parameter* p, unsigned int regionIdx, real value)
                                 { p->setInRegion(regionIdx, value);
       })
-      .def("load_file", &Parameter::loadFile);
+      .def("read_ovf", &Parameter::loadFile);
 
   // ===== VectorParameter =====
   py::class_<VectorParameter, FieldQuantity>(m, "VectorParameter")
@@ -106,7 +106,7 @@ void wrap_parameter(py::module& m) {
       .def("set_in_region", [](VectorParameter* p, unsigned int regionIdx, real3 value)
                                 { p->setInRegion(regionIdx, value);
       })
-      .def("load_file", &VectorParameter::loadFile);
+      .def("read_ovf", &VectorParameter::loadFile);
 
   // ===== InterParameter =====
   py::class_<InterParameter>(m, "InterParameter")

--- a/src/bindings/wrap_parameter.cpp
+++ b/src/bindings/wrap_parameter.cpp
@@ -36,7 +36,8 @@ void wrap_parameter(py::module& m) {
       })
       .def("set_in_region", [](Parameter* p, unsigned int regionIdx, real value)
                                 { p->setInRegion(regionIdx, value);
-      });
+      })
+      .def("load_file", &Parameter::loadFile);
 
   // ===== VectorParameter =====
   py::class_<VectorParameter, FieldQuantity>(m, "VectorParameter")
@@ -104,7 +105,8 @@ void wrap_parameter(py::module& m) {
       })
       .def("set_in_region", [](VectorParameter* p, unsigned int regionIdx, real3 value)
                                 { p->setInRegion(regionIdx, value);
-      });
+      })
+      .def("load_file", &VectorParameter::loadFile);
 
   // ===== InterParameter =====
   py::class_<InterParameter>(m, "InterParameter")

--- a/src/bindings/wrap_variable.cpp
+++ b/src/bindings/wrap_variable.cpp
@@ -12,5 +12,6 @@ void wrap_variable(py::module& m) {
         Field tmp(v->system(), v->ncomp());
         setArrayInField(tmp, data);
         v->set(std::move(tmp));
-      });
+      })
+      .def("load_file", &Variable::loadFile);
 }

--- a/src/bindings/wrap_variable.cpp
+++ b/src/bindings/wrap_variable.cpp
@@ -13,5 +13,5 @@ void wrap_variable(py::module& m) {
         setArrayInField(tmp, data);
         v->set(std::move(tmp));
       })
-      .def("load_file", &Variable::loadFile);
+      .def("read_ovf", &Variable::loadFile);
 }

--- a/src/core/datatypes.hpp
+++ b/src/core/datatypes.hpp
@@ -16,11 +16,13 @@
 using real = float;
 using real3 = float3;
 using complex = cuComplex;
+constexpr float realControlnumber = 1234567.0;
 inline float stor(const std::string& s) { return std::stof(s); }
 #elif FP_PRECISION == DOUBLE
 using real = double;
 using real3 = double3;
 using complex = cuDoubleComplex;
+constexpr double realControlnumber = 123456789012345.0;
 inline double stor(const std::string& s) { return std::stod(s); }
 #else
 #error FP_PRECISION should be SINGLE or DOUBLE

--- a/src/core/datatypes.hpp
+++ b/src/core/datatypes.hpp
@@ -16,10 +16,12 @@
 using real = float;
 using real3 = float3;
 using complex = cuComplex;
+inline float stor(const std::string& s) { return std::stof(s); }
 #elif FP_PRECISION == DOUBLE
 using real = double;
 using real3 = double3;
 using complex = cuDoubleComplex;
+inline double stor(const std::string& s) { return std::stod(s); }
 #else
 #error FP_PRECISION should be SINGLE or DOUBLE
 #endif

--- a/src/core/fieldquantity.cpp
+++ b/src/core/fieldquantity.cpp
@@ -92,7 +92,7 @@ void FieldQuantity::writeOvf(const std::string& filename) const {
     for (real val : data) {
       out.write(reinterpret_cast<const char*>(&val), sizeof(real));
     }
-
+    out << "\n";
     out << "# End: Data Text\n";
     out << "# End: Segment\n";
 

--- a/src/core/fieldquantity.cpp
+++ b/src/core/fieldquantity.cpp
@@ -87,8 +87,7 @@ void FieldQuantity::writeOvf(const std::string& filename) const {
     std::vector<real> data = eval().getData();
 
     // Write data
-    real controlnumber = 1234567.0; // ovf control number
-    out.write(reinterpret_cast<const char*>(&controlnumber), sizeof(real));
+    out.write(reinterpret_cast<const char*>(&realControlnumber), sizeof(real));
     int i = 0;
     for (real val : data) {
       out.write(reinterpret_cast<const char*>(&val), sizeof(real));

--- a/src/core/fieldquantity.cpp
+++ b/src/core/fieldquantity.cpp
@@ -1,6 +1,8 @@
 #include "fieldquantity.hpp"
 
+#include <fstream>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 #include "datatypes.hpp"
@@ -36,3 +38,71 @@ const World* FieldQuantity::world() const {
     return sys->world();
   return nullptr;
 }
+
+// Create an ovf2 text file
+void FieldQuantity::writeOvf(const std::string& filename) const {
+    std::ofstream out(filename);
+    if (!out.is_open()) {
+        throw std::runtime_error("Cannot open file " + filename);
+    }
+    
+    int3 gridSize = system()->grid().size();
+    real3 cellSize = system().get()->world()->cellsize();
+
+    // Write header
+    out << "# OOMMF OVF 2.0\n";
+    out << "# Segment count: 1\n";
+    out << "# Begin: Segment\n";
+    out << "# Begin: Header\n";
+    out << "# Title: " << name() << "\n";
+    out << "# meshtype: rectangular\n";
+    out << "# meshunit: m\n";
+    out << "# xmin: 0\n";
+    out << "# ymin: 0\n";
+    out << "# zmin: 0\n";
+    out << "# xmax: " << cellSize.x * gridSize.x << "\n";
+    out << "# ymax: " << cellSize.y * gridSize.y << "\n";
+    out << "# zmax: " << cellSize.z * gridSize.z << "\n";
+    out << "# valuedim: " << ncomp() << "\n";
+    if (ncomp() == 1) {out << "# valuelabels: " << name() << "\n";}
+    else if (ncomp() == 3) {
+      out << "# valuelabels: " << name() << "_x " << name() << "_y " << name() << "_z\n";
+    }
+    if (unit() == "") {out << "# valueunit: 1";}
+    else {out << "# valueunit: " << unit() << "\n";}
+    out << "# Desc: Total simulation time: " << system()->world()->time() << " s\n";
+    out << "# xbase: " << cellSize.x/2 << "\n";
+    out << "# ybase: " << cellSize.y/2 << "\n";
+    out << "# zbase: " << cellSize.z/2 << "\n";
+    out << "# xnodes: " << gridSize.x << "\n";
+    out << "# ynodes: " << gridSize.y << "\n";
+    out << "# znodes: " << gridSize.z << "\n";
+    out << "# xstepsize: " << cellSize.x << "\n";
+    out << "# ystepsize: " << cellSize.y << "\n";
+    out << "# zstepsize: " << cellSize.z << "\n";
+    out << "# End: Header\n";
+    out << "# Begin: Data Text\n";
+
+    int nc = ncomp();
+    std::vector<real> data = eval().getData();
+
+    // Write data (assumes ncomp = 3)
+    int i = 0;
+    for (real val : data) {
+      out << val;
+      i += 1;
+      if (i == nc) {
+        out << "\n";
+        i = 0;
+      }
+      else {
+        out << " ";
+      }
+    }
+
+    out << "# End: Data Text\n";
+    out << "# End: Segment\n";
+
+    out.close();
+}
+

--- a/src/core/fieldquantity.cpp
+++ b/src/core/fieldquantity.cpp
@@ -39,7 +39,7 @@ const World* FieldQuantity::world() const {
   return nullptr;
 }
 
-// Create an ovf2 text file
+// Create an ovf2 binary file
 void FieldQuantity::writeOvf(const std::string& filename) const {
     std::ofstream out(filename);
     if (!out.is_open()) {

--- a/src/core/fieldquantity.cpp
+++ b/src/core/fieldquantity.cpp
@@ -86,18 +86,12 @@ void FieldQuantity::writeOvf(const std::string& filename) const {
     int nc = ncomp();
     std::vector<real> data = eval().getData();
 
-    // Write data (assumes ncomp = 3)
+    // Write data
+    real controlnumber = 1234567.0; // ovf control number
+    out.write(reinterpret_cast<const char*>(&controlnumber), sizeof(real));
     int i = 0;
     for (real val : data) {
-      out << val;
-      i += 1;
-      if (i == nc) {
-        out << "\n";
-        i = 0;
-      }
-      else {
-        out << " ";
-      }
+      out.write(reinterpret_cast<const char*>(&val), sizeof(real));
     }
 
     out << "# End: Data Text\n";

--- a/src/core/fieldquantity.cpp
+++ b/src/core/fieldquantity.cpp
@@ -68,7 +68,7 @@ void FieldQuantity::writeOvf(const std::string& filename) const {
     else if (ncomp() == 3) {
       out << "# valuelabels: " << name() << "_x " << name() << "_y " << name() << "_z\n";
     }
-    if (unit() == "") {out << "# valueunit: 1";}
+    if (unit() == "") {out << "# valueunit: 1\n";}
     else {out << "# valueunit: " << unit() << "\n";}
     out << "# Desc: Total simulation time: " << system()->world()->time() << " s\n";
     out << "# xbase: " << cellSize.x/2 << "\n";

--- a/src/core/fieldquantity.hpp
+++ b/src/core/fieldquantity.hpp
@@ -60,6 +60,8 @@ class FieldQuantity {
   /// Return the world in which the quantity lives.
   /// Return nullptr if the system is not attached to a World.
   const World* world() const;
+
+  void writeOvf(const std::string& filename) const;
 };
 
 inline bool sameFieldDimensions(const FieldQuantity& q1,

--- a/src/core/parameter.cu
+++ b/src/core/parameter.cu
@@ -1,4 +1,7 @@
+#include <fstream>
+#include <iostream>
 #include <memory>
+#include <sstream>
 
 #include "datatypes.hpp"
 #include "field.hpp"
@@ -101,6 +104,93 @@ CuParameter Parameter::cu() const {
   return CuParameter(this);
 }
 
+void Parameter::loadFile(std::string file) {
+  std::ifstream in(file);
+  if (!in.is_open()) {
+      throw std::runtime_error("Cannot open file " + file);
+  }
+
+  std::string line;
+  bool inHeader = false;
+  bool inData = false;
+  std::vector<real> data;
+
+  while (std::getline(in, line)) {
+    // Skip comment lines
+    if (line.empty()) continue;
+
+    if (line.find("# Begin: Header") != std::string::npos) {
+      inHeader = true;
+    } else if (line.find("# End: Header") != std::string::npos) {
+      inHeader = false;
+    } else if (line.find("# Begin: Data Text") != std::string::npos) {
+      inData = true;
+    } else if (line.find("# End: Data Text") != std::string::npos) {
+      inData = false;
+    } else if (inHeader) {
+      std::istringstream ss(line);
+      std::string tag;
+      ss >> tag; // skip '#'
+      ss >> tag;
+
+      if (tag == "Title:") {
+        std::getline(ss, tag);
+        tag = tag.substr(1); // remove leading space
+        // TODO: change name
+      } else if (tag == "valuedim:") {
+        ss >> tag;
+        if (ncomp() != stoi(tag)) {
+          throw std::invalid_argument("The number of components does not match.");
+        }
+      } else if (tag == "valueunit:") {
+        ss >> tag;
+        if (tag == "1") {tag = "";}
+        if (unit() != tag) {
+          throw std::invalid_argument("The units don't match.");
+        }
+      } else if (tag == "xnodes:") {
+        ss >> tag;
+        if (system()->grid().size().x != stoi(tag)) {
+          throw std::invalid_argument("The number of x-cells don't match.");
+        }
+      } else if (tag == "ynodes:") {
+        ss >> tag;
+        if (system()->grid().size().y != stoi(tag)) {
+          throw std::invalid_argument("The number of y-cells don't match.");
+        }
+      } else if (tag == "znodes:") {
+        ss >> tag;
+        if (system()->grid().size().z != stoi(tag)) {
+          throw std::invalid_argument("The number of z-cells don't match.");
+        }
+      } else if (tag == "xstepsize:") {
+        ss >> tag;
+        if (system().get()->world()->cellsize().x != stor(tag)) {
+          std::cout << std::to_string(system().get()->world()->cellsize().x) << " " << stod(tag);
+          throw std::invalid_argument("The cell size x-values don't match.");
+        }
+      } else if (tag == "ystepsize:") {
+        ss >> tag;
+        if (system().get()->world()->cellsize().y != stor(tag)) {
+          throw std::invalid_argument("The cell size y-values don't match.");
+        }
+      } else if (tag == "zstepsize:") {
+        ss >> tag;
+        if (system().get()->world()->cellsize().z != stor(tag)) {
+          throw std::invalid_argument("The cell size z-values don't match.");
+        }
+      }
+    } else if (inData) {
+      std::istringstream ss(line);
+      real value;
+      while (ss >> value) {
+        data.push_back(value);
+      }
+    }
+  }
+  staticField_->setData(data);
+}
+
 VectorParameter::VectorParameter(std::shared_ptr<const System> system,
                                  real3 value,
                                  std::string name, std::string unit)
@@ -191,6 +281,93 @@ real3 VectorParameter::getUniformValue() const {
     throw std::invalid_argument("Cannot get uniform value of non-uniform Parameter.");
   }
   return uniformValue_;
+}
+
+void VectorParameter::loadFile(std::string file) {
+  std::ifstream in(file);
+  if (!in.is_open()) {
+      throw std::runtime_error("Cannot open file " + file);
+  }
+
+  std::string line;
+  bool inHeader = false;
+  bool inData = false;
+  std::vector<real> data;
+
+  while (std::getline(in, line)) {
+    // Skip comment lines
+    if (line.empty()) continue;
+
+    if (line.find("# Begin: Header") != std::string::npos) {
+      inHeader = true;
+    } else if (line.find("# End: Header") != std::string::npos) {
+      inHeader = false;
+    } else if (line.find("# Begin: Data Text") != std::string::npos) {
+      inData = true;
+    } else if (line.find("# End: Data Text") != std::string::npos) {
+      inData = false;
+    } else if (inHeader) {
+      std::istringstream ss(line);
+      std::string tag;
+      ss >> tag; // skip '#'
+      ss >> tag;
+
+      if (tag == "Title:") {
+        std::getline(ss, tag);
+        tag = tag.substr(1); // remove leading space
+        // TODO: change name
+      } else if (tag == "valuedim:") {
+        ss >> tag;
+        if (ncomp() != stoi(tag)) {
+          throw std::invalid_argument("The number of components does not match.");
+        }
+      } else if (tag == "valueunit:") {
+        ss >> tag;
+        if (tag == "1") {tag = "";}
+        if (unit() != tag) {
+          throw std::invalid_argument("The units don't match.");
+        }
+      } else if (tag == "xnodes:") {
+        ss >> tag;
+        if (system()->grid().size().x != stoi(tag)) {
+          throw std::invalid_argument("The number of x-cells don't match.");
+        }
+      } else if (tag == "ynodes:") {
+        ss >> tag;
+        if (system()->grid().size().y != stoi(tag)) {
+          throw std::invalid_argument("The number of y-cells don't match.");
+        }
+      } else if (tag == "znodes:") {
+        ss >> tag;
+        if (system()->grid().size().z != stoi(tag)) {
+          throw std::invalid_argument("The number of z-cells don't match.");
+        }
+      } else if (tag == "xstepsize:") {
+        ss >> tag;
+        if (system().get()->world()->cellsize().x != stor(tag)) {
+          std::cout << std::to_string(system().get()->world()->cellsize().x) << " " << stod(tag);
+          throw std::invalid_argument("The cell size x-values don't match.");
+        }
+      } else if (tag == "ystepsize:") {
+        ss >> tag;
+        if (system().get()->world()->cellsize().y != stor(tag)) {
+          throw std::invalid_argument("The cell size y-values don't match.");
+        }
+      } else if (tag == "zstepsize:") {
+        ss >> tag;
+        if (system().get()->world()->cellsize().z != stor(tag)) {
+          throw std::invalid_argument("The cell size z-values don't match.");
+        }
+      }
+    } else if (inData) {
+      std::istringstream ss(line);
+      real value;
+      while (ss >> value) {
+        data.push_back(value);
+      }
+    }
+  }
+  staticField_->setData(data);
 }
 
 CuVectorParameter VectorParameter::cu() const {

--- a/src/core/parameter.cu
+++ b/src/core/parameter.cu
@@ -113,7 +113,6 @@ void Parameter::loadFile(std::string file) {
   std::string line;
   bool inHeader = false;
   real controlnumber;
-  real realControlnumber = 1234567.0;
 
   while (std::getline(in, line)) {
     // Skip comment lines
@@ -294,7 +293,6 @@ void VectorParameter::loadFile(std::string file) {
   std::string line;
   bool inHeader = false;
   real controlnumber;
-  real realControlnumber = 1234567.0;
 
   while (std::getline(in, line)) {
     // Skip comment lines

--- a/src/core/parameter.cu
+++ b/src/core/parameter.cu
@@ -104,6 +104,7 @@ CuParameter Parameter::cu() const {
   return CuParameter(this);
 }
 
+// Read ovf2 binary file
 void Parameter::loadFile(std::string file) {
   std::ifstream in(file);
   if (!in.is_open()) {
@@ -114,6 +115,7 @@ void Parameter::loadFile(std::string file) {
   bool inHeader = false;
   real controlnumber;
 
+  // Check the file and make sure it is compatible
   while (std::getline(in, line)) {
     // Skip comment lines
     if (line.empty()) continue;
@@ -133,7 +135,7 @@ void Parameter::loadFile(std::string file) {
       if (tag == "Title:") {
         std::getline(ss, tag);
         tag = tag.substr(1); // remove leading space
-        // TODO: change name
+        // TODO: change name?
       } else if (tag == "valuedim:") {
         ss >> tag;
         if (ncomp() != stoi(tag)) {
@@ -179,6 +181,8 @@ void Parameter::loadFile(std::string file) {
       }
     }
   }
+
+  // Read the actual data
   size_t totalValues = system()->grid().size().x * system()->grid().size().y * system()->grid().size().z * ncomp();
   std::vector<real> data(totalValues);
   in.read(reinterpret_cast<char*>(&controlnumber), sizeof(real));
@@ -284,6 +288,7 @@ real3 VectorParameter::getUniformValue() const {
   return uniformValue_;
 }
 
+// Read ovf2 binary file
 void VectorParameter::loadFile(std::string file) {
   std::ifstream in(file);
   if (!in.is_open()) {
@@ -294,6 +299,7 @@ void VectorParameter::loadFile(std::string file) {
   bool inHeader = false;
   real controlnumber;
 
+  // Check the file and make sure it is compatible
   while (std::getline(in, line)) {
     // Skip comment lines
     if (line.empty()) continue;
@@ -313,7 +319,7 @@ void VectorParameter::loadFile(std::string file) {
       if (tag == "Title:") {
         std::getline(ss, tag);
         tag = tag.substr(1); // remove leading space
-        // TODO: change name
+        // TODO: change name?
       } else if (tag == "valuedim:") {
         ss >> tag;
         if (ncomp() != stoi(tag)) {
@@ -359,6 +365,8 @@ void VectorParameter::loadFile(std::string file) {
       }
     }
   }
+
+  // Read the actual data
   size_t totalValues = system()->grid().size().x * system()->grid().size().y * system()->grid().size().z * ncomp();
   std::vector<real> data(totalValues);
   in.read(reinterpret_cast<char*>(&controlnumber), sizeof(real));

--- a/src/core/parameter.cu
+++ b/src/core/parameter.cu
@@ -188,7 +188,9 @@ void Parameter::loadFile(std::string file) {
       }
     }
   }
-  staticField_->setData(data);
+  Field staticField = Field(system(), ncomp());
+  staticField.setData(data);
+  set(staticField);
 }
 
 VectorParameter::VectorParameter(std::shared_ptr<const System> system,
@@ -367,7 +369,9 @@ void VectorParameter::loadFile(std::string file) {
       }
     }
   }
-  staticField_->setData(data);
+  Field staticField = Field(system(), ncomp());
+  staticField.setData(data);
+  set(staticField);
 }
 
 CuVectorParameter VectorParameter::cu() const {

--- a/src/core/parameter.cu
+++ b/src/core/parameter.cu
@@ -112,8 +112,8 @@ void Parameter::loadFile(std::string file) {
 
   std::string line;
   bool inHeader = false;
-  bool inData = false;
-  std::vector<real> data;
+  real controlnumber;
+  real realControlnumber = 1234567.0;
 
   while (std::getline(in, line)) {
     // Skip comment lines
@@ -124,9 +124,7 @@ void Parameter::loadFile(std::string file) {
     } else if (line.find("# End: Header") != std::string::npos) {
       inHeader = false;
     } else if (line.find("# Begin: Data Text") != std::string::npos) {
-      inData = true;
-    } else if (line.find("# End: Data Text") != std::string::npos) {
-      inData = false;
+      break;
     } else if (inHeader) {
       std::istringstream ss(line);
       std::string tag;
@@ -180,14 +178,16 @@ void Parameter::loadFile(std::string file) {
           throw std::invalid_argument("The cell size z-values don't match.");
         }
       }
-    } else if (inData) {
-      std::istringstream ss(line);
-      real value;
-      while (ss >> value) {
-        data.push_back(value);
-      }
     }
   }
+  size_t totalValues = system()->grid().size().x * system()->grid().size().y * system()->grid().size().z * ncomp();
+  std::vector<real> data(totalValues);
+  in.read(reinterpret_cast<char*>(&controlnumber), sizeof(real));
+  if (controlnumber != realControlnumber) {
+    throw std::runtime_error("Unexpected control number: " + std::to_string(controlnumber));
+  }
+  in.read(reinterpret_cast<char*>(data.data()), totalValues * sizeof(real));
+
   Field staticField = Field(system(), ncomp());
   staticField.setData(data);
   set(staticField);
@@ -293,8 +293,8 @@ void VectorParameter::loadFile(std::string file) {
 
   std::string line;
   bool inHeader = false;
-  bool inData = false;
-  std::vector<real> data;
+  real controlnumber;
+  real realControlnumber = 1234567.0;
 
   while (std::getline(in, line)) {
     // Skip comment lines
@@ -305,9 +305,7 @@ void VectorParameter::loadFile(std::string file) {
     } else if (line.find("# End: Header") != std::string::npos) {
       inHeader = false;
     } else if (line.find("# Begin: Data Text") != std::string::npos) {
-      inData = true;
-    } else if (line.find("# End: Data Text") != std::string::npos) {
-      inData = false;
+      break;
     } else if (inHeader) {
       std::istringstream ss(line);
       std::string tag;
@@ -361,14 +359,16 @@ void VectorParameter::loadFile(std::string file) {
           throw std::invalid_argument("The cell size z-values don't match.");
         }
       }
-    } else if (inData) {
-      std::istringstream ss(line);
-      real value;
-      while (ss >> value) {
-        data.push_back(value);
-      }
     }
   }
+  size_t totalValues = system()->grid().size().x * system()->grid().size().y * system()->grid().size().z * ncomp();
+  std::vector<real> data(totalValues);
+  in.read(reinterpret_cast<char*>(&controlnumber), sizeof(real));
+  if (controlnumber != realControlnumber) {
+    throw std::runtime_error("Unexpected control number: " + std::to_string(controlnumber));
+  }
+  in.read(reinterpret_cast<char*>(data.data()), totalValues * sizeof(real));
+
   Field staticField = Field(system(), ncomp());
   staticField.setData(data);
   set(staticField);

--- a/src/core/parameter.hpp
+++ b/src/core/parameter.hpp
@@ -37,6 +37,8 @@ class Parameter : public FieldQuantity, public DynamicParameter<real> {
   /** Send parameter data to the device. */
   CuParameter cu() const;
 
+  void loadFile(std::string file);
+
  private:
   std::shared_ptr<const System> system_;
   real uniformValue_;
@@ -133,6 +135,8 @@ class VectorParameter : public FieldQuantity, public DynamicParameter<real3> {
   real3 getUniformValue() const;
 
   CuVectorParameter cu() const;
+
+  void loadFile(std::string file);
 
  private:
   std::shared_ptr<const System> system_;

--- a/src/core/variable.cpp
+++ b/src/core/variable.cpp
@@ -70,6 +70,7 @@ void Variable::set(real3 value) const {
   field_->setUniformComponent(2, value.z);
 }
 
+// Read ovf2 binary file
 void Variable::loadFile(std::string file) {
   std::ifstream in(file, std::ios::binary);
   if (!in.is_open()) {
@@ -81,6 +82,7 @@ void Variable::loadFile(std::string file) {
   bool firstLine = true;
   real controlnumber;
 
+  // Check the file and make sure it is compatible
   while (std::getline(in, line)) {
     // Skip comment lines
     if (line.empty()) continue;
@@ -100,7 +102,7 @@ void Variable::loadFile(std::string file) {
       if (tag == "Title:") {
         std::getline(ss, tag);
         tag = tag.substr(1); // remove leading space
-        // TODO: change name
+        // TODO: change name?
       } else if (tag == "valuedim:") {
         ss >> tag;
         if (ncomp() != stoi(tag)) {
@@ -146,6 +148,8 @@ void Variable::loadFile(std::string file) {
       }
     }
   }
+
+  // Read the actual data
   size_t totalValues = system()->grid().size().x * system()->grid().size().y * system()->grid().size().z * ncomp();
   std::vector<real> data(totalValues);
   in.read(reinterpret_cast<char*>(&controlnumber), sizeof(real));

--- a/src/core/variable.cpp
+++ b/src/core/variable.cpp
@@ -1,8 +1,11 @@
 #include "variable.hpp"
 
+#include <fstream>
+#include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <sstream>
 
 #include "field.hpp"
 #include "fieldops.hpp"
@@ -65,6 +68,93 @@ void Variable::set(real3 value) const {
   field_->setUniformComponent(0, value.x);
   field_->setUniformComponent(1, value.y);
   field_->setUniformComponent(2, value.z);
+}
+
+void Variable::loadFile(std::string file) {
+  std::ifstream in(file);
+  if (!in.is_open()) {
+      throw std::runtime_error("Cannot open file " + file);
+  }
+
+  std::string line;
+  bool inHeader = false;
+  bool inData = false;
+  std::vector<real> data;
+
+  while (std::getline(in, line)) {
+    // Skip comment lines
+    if (line.empty()) continue;
+
+    if (line.find("# Begin: Header") != std::string::npos) {
+      inHeader = true;
+    } else if (line.find("# End: Header") != std::string::npos) {
+      inHeader = false;
+    } else if (line.find("# Begin: Data Text") != std::string::npos) {
+      inData = true;
+    } else if (line.find("# End: Data Text") != std::string::npos) {
+      inData = false;
+    } else if (inHeader) {
+      std::istringstream ss(line);
+      std::string tag;
+      ss >> tag; // skip '#'
+      ss >> tag;
+
+      if (tag == "Title:") {
+        std::getline(ss, tag);
+        tag = tag.substr(1); // remove leading space
+        // TODO: change name
+      } else if (tag == "valuedim:") {
+        ss >> tag;
+        if (ncomp() != stoi(tag)) {
+          throw std::invalid_argument("The number of components does not match.");
+        }
+      } else if (tag == "valueunit:") {
+        ss >> tag;
+        if (tag == "1") {tag = "";}
+        if (unit() != tag) {
+          throw std::invalid_argument("The units don't match.");
+        }
+      } else if (tag == "xnodes:") {
+        ss >> tag;
+        if (system()->grid().size().x != stoi(tag)) {
+          throw std::invalid_argument("The number of x-cells don't match.");
+        }
+      } else if (tag == "ynodes:") {
+        ss >> tag;
+        if (system()->grid().size().y != stoi(tag)) {
+          throw std::invalid_argument("The number of y-cells don't match.");
+        }
+      } else if (tag == "znodes:") {
+        ss >> tag;
+        if (system()->grid().size().z != stoi(tag)) {
+          throw std::invalid_argument("The number of z-cells don't match.");
+        }
+      } else if (tag == "xstepsize:") {
+        ss >> tag;
+        if (system().get()->world()->cellsize().x != stor(tag)) {
+          std::cout << std::to_string(system().get()->world()->cellsize().x) << " " << stod(tag);
+          throw std::invalid_argument("The cell size x-values don't match.");
+        }
+      } else if (tag == "ystepsize:") {
+        ss >> tag;
+        if (system().get()->world()->cellsize().y != stor(tag)) {
+          throw std::invalid_argument("The cell size y-values don't match.");
+        }
+      } else if (tag == "zstepsize:") {
+        ss >> tag;
+        if (system().get()->world()->cellsize().z != stor(tag)) {
+          throw std::invalid_argument("The cell size z-values don't match.");
+        }
+      }
+    } else if (inData) {
+      std::istringstream ss(line);
+      real value;
+      while (ss >> value) {
+        data.push_back(value);
+      }
+    }
+  }
+  field_->setData(data);
 }
 
 NormalizedVariable::NormalizedVariable(std::shared_ptr<const System> system,

--- a/src/core/variable.cpp
+++ b/src/core/variable.cpp
@@ -80,7 +80,6 @@ void Variable::loadFile(std::string file) {
   bool inHeader = false;
   bool firstLine = true;
   real controlnumber;
-  real realControlnumber = 1234567.0;
 
   while (std::getline(in, line)) {
     // Skip comment lines

--- a/src/core/variable.hpp
+++ b/src/core/variable.hpp
@@ -32,6 +32,7 @@ class Variable : public FieldQuantity {
   void operator=(const Field& f) const { set(f); }
   void operator=(real val) const { set(val); }
   void operator=(real3 val) const { set(val); }
+  void loadFile(std::string);
 
  protected:
   Field* field_;

--- a/test/test_ovf.py
+++ b/test/test_ovf.py
@@ -6,7 +6,7 @@ import os
 
 from mumaxplus import Grid, World, Ferromagnet
 
-ATOL = 2e-7
+ATOL = 0
 
 def max_absolute_error(result, wanted):
     err = np.linalg.norm(result - wanted, axis=0)
@@ -36,7 +36,7 @@ class TestOvf:
         magnet.magnetization.read_ovf("test_m.ovf")
         os.remove("test_m.ovf")
         
-        assert max_absolute_error(magnet.magnetization.eval(), self.magnet.magnetization.eval()) < ATOL
+        assert max_absolute_error(magnet.magnetization.eval(), self.magnet.magnetization.eval()) <= ATOL
     
     def test_read_ku1(self):
         world = World((1e-9, 3e-9, 4e-9))
@@ -44,7 +44,7 @@ class TestOvf:
         magnet.ku1.read_ovf("test_ku1.ovf")
         os.remove("test_ku1.ovf")
         
-        assert max_absolute_error(magnet.ku1.eval(), self.magnet.ku1.eval()) < ATOL
+        assert max_absolute_error(magnet.ku1.eval(), self.magnet.ku1.eval()) <= ATOL
     
     def test_read_anisU(self):
         world = World((1e-9, 3e-9, 4e-9))
@@ -52,4 +52,4 @@ class TestOvf:
         magnet.anisU.read_ovf("test_anisU.ovf")
         os.remove("test_anisU.ovf")
         
-        assert max_absolute_error(magnet.anisU.eval(), self.magnet.anisU.eval()) < ATOL
+        assert max_absolute_error(magnet.anisU.eval(), self.magnet.anisU.eval()) <= ATOL

--- a/test/test_ovf.py
+++ b/test/test_ovf.py
@@ -1,4 +1,4 @@
-"""This file tests the reading and writing of OVF 2.0 text files
+"""This file tests the reading and writing of OVF 2.0 binary files
 """
 
 import numpy as np

--- a/test/test_ovf.py
+++ b/test/test_ovf.py
@@ -1,0 +1,55 @@
+"""This file tests the reading and writing of OVF 2.0 text files
+"""
+
+import numpy as np
+import os
+
+from mumaxplus import Grid, World, Ferromagnet
+
+ATOL = 2e-7
+
+def max_absolute_error(result, wanted):
+    err = np.linalg.norm(result - wanted, axis=0)
+    return np.max(err)
+
+class TestOvf:
+    def setup_class(self):
+        self.world = World((1e-9, 3e-9, 4e-9))
+        self.magnet = Ferromagnet(self.world, Grid((3, 2, 1)))
+        self.magnet.magnetization = (1, 0.1, 0)
+        self.magnet.minimize()
+        
+        self.magnet.ku1 = 2
+        self.magnet.anisU = (1,0,0)
+
+        print(self.magnet.magnetization.eval())
+
+        self.magnet.magnetization.write_ovf("test_m.ovf")
+        self.magnet.ku1.write_ovf("test_ku1.ovf")
+        self.magnet.anisU.write_ovf("test_anisU.ovf")
+    
+    def test_read_m(self):
+        print("helloooo")
+        world = World((1e-9, 3e-9, 4e-9))
+        magnet = Ferromagnet(world, Grid((3, 2, 1)))
+        print("hello")
+        magnet.magnetization.read_ovf("test_m.ovf")
+        os.remove("test_m.ovf")
+        
+        assert max_absolute_error(magnet.magnetization.eval(), self.magnet.magnetization.eval()) < ATOL
+    
+    def test_read_ku1(self):
+        world = World((1e-9, 3e-9, 4e-9))
+        magnet = Ferromagnet(world, Grid((3, 2, 1)))
+        magnet.ku1.read_ovf("test_ku1.ovf")
+        os.remove("test_ku1.ovf")
+        
+        assert max_absolute_error(magnet.ku1.eval(), self.magnet.ku1.eval()) < ATOL
+    
+    def test_read_anisU(self):
+        world = World((1e-9, 3e-9, 4e-9))
+        magnet = Ferromagnet(world, Grid((3, 2, 1)))
+        magnet.anisU.read_ovf("test_anisU.ovf")
+        os.remove("test_anisU.ovf")
+        
+        assert max_absolute_error(magnet.anisU.eval(), self.magnet.anisU.eval()) < ATOL


### PR DESCRIPTION
This addition adds a function to some classes in order to read and write .ovf files.

All fieldQuantities can now write a .ovf file when you use `.write_ovf("file.ovf")`.
All variables and parameters can read a .ovf file to set their values `.read_ovf("file.ovf")`
The style of the files is ovf2 with binary data. It uses binary4 in SINGLE precision and binary8 in DOUBLE precision.

This PR also includes a small test where some .ovf files are generated and then used to set some variables and parameters. The original values are then compared to the freshly set values and they should be identical.