### PR TITLE
Add extent property to system/magnet

### DIFF
--- a/mumaxplus/magnet.py
+++ b/mumaxplus/magnet.py
@@ -135,6 +135,17 @@ class Magnet(ABC):
         return self._impl.system.center
 
     @property
+    def extent(self) ->tuple[float]:
+        """Extent of the magnet.
+
+        Returns
+        -------
+        extent: tuple[float] of size 6
+           Positions of the edges of the magnet: (xmin, xmax, ymin, ymax, zmin, zmax).
+        """
+        return self._impl.system.extent
+
+    @property
     def world(self):
         """Return the World of which the magnet is a part."""
         from .world import World  # imported here to avoid circular imports

--- a/src/bindings/wrap_system.cpp
+++ b/src/bindings/wrap_system.cpp
@@ -44,6 +44,10 @@ void wrap_system(py::module& m) {
       .def("cell_position", &System::cellPosition)
       .def_property_readonly("origin", &System::origin)
       .def_property_readonly("center", &System::center)
+      .def_property_readonly("extent", [](const System* system) {
+          std::array<real, 6> e = system->extent();
+          // return tuple, not list
+          return py::make_tuple(e[0], e[1], e[2], e[3], e[4], e[5]); })
       .def_property_readonly("geometry", [](const System* system) {
           return get_data<bool>(system, &System::geometry, true); })
       .def_property_readonly("regions", [](const System* system) {

--- a/src/core/datatypes.hpp
+++ b/src/core/datatypes.hpp
@@ -71,6 +71,15 @@ inline __host__ std::ostream& operator<<(std::ostream& os, const int3 a) {
   return os;
 }
 
+// explicit conversion functions because implicit is impossible
+__CUDAOP__ real3 int3_to_real3(const int3& a) {
+  return real3{static_cast<real>(a.x), static_cast<real>(a.y), static_cast<real>(a.z)};
+}
+
+__CUDAOP__ int3 real3_to_int3(const real3& a) {
+  return int3{static_cast<int>(a.x), static_cast<int>(a.y), static_cast<int>(a.z)};
+}
+
 __CUDAOP__ void operator+=(real3& a, const real3& b) {
   a.x += b.x;
   a.y += b.y;

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -67,6 +67,12 @@ real3 System::center() const {
   return (corner2 + corner1) / 2;
 }
 
+std::array<real, 6> System::extent() const {
+  real3 minEdge = origin() - 0.5 * cellsize();
+  real3 maxEdge = minEdge + int3_to_real3(grid().size()) * cellsize();
+  return {minEdge.x, maxEdge.x, minEdge.y, maxEdge.y, minEdge.z, maxEdge.z};
+}
+
 const GpuBuffer<bool>& System::geometry() const {
   return geometry_;
 }

--- a/src/core/system.hpp
+++ b/src/core/system.hpp
@@ -42,6 +42,10 @@ class System {
   /** Return the position of the center of this system in the world. */
   real3 center() const;
 
+  /** Return the positions of the edges of this system in the world.
+   *  {xmin, xmax, ymin, ymax, zmin, zmax} */
+  std::array<real, 6> extent() const;
+
   /** Get the geometry of the system. */
   const GpuBuffer<bool>& geometry() const;
 


### PR DESCRIPTION
I was tired of copy-pasting the function `_quantity_img_xyz_extent` from `show.py`, so now it is a property of System (where it belongs) and Magnet (because there is no System wrapper class on the Python side). It returns `(xmin, xmax, ymin, ymax, zmin, zmax)`, similar to extent of matplotlib imshow, but extended to 3D.