### PR TITLE
Fix #93: Compiling on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ All demonstrations in the paper were simulated using version [v1.1.0](https://gi
 You should install these yourself
 * CUDA Toolkit 10.0 or later
 * A C++ compiler which supports C++17, such as GCC
-* On Windows (good luck): MSVC 2019
+* On Windows: MSVC 2019 or 2022
 
 These will be installed automatically within the conda environment
 * cmake 4.0.0
@@ -70,29 +70,21 @@ add_definitions(-DFP_PRECISION=DOUBLE) # FP_PRECISION should be SINGLE or DOUBLE
 
 ### Windows
 
-**These instructions are old and worked at some point (2021), but not today. If you are brave enough to try Windows and you manage to get it working, please let us know!**
-
-1. Install Visual Studio 2019 and the desktop development with C++ workload
-2. Install CUDA Toolkit 10.x
-3. Install cmake
-4. Download the pybind11 submodule with git
-```
+1. Install Microsoft Visual Studio with the "Desktop development with C++" workload
+2. Install the [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit-archive) *(version 10.0 or later)*
+3. Download the pybind11 submodule with git:
+```powershell
 git submodule init
 git submodule update
 ```
-5. Install Python packages using conda
-```
+4. Install Python packages using conda:
+```powershell
 conda env create -f environment.yml
 ```
-6. Build `mumaxplus` using `setuptools`
-```
-activate mumaxplus
-python setup.py develop
-```
-or `conda`
-```
+5. Build `mumaxplus` using `pip` and `setuptools`:
+```powershell
 conda activate mumaxplus
-conda develop -b .
+pip install -v .
 ```
 
 ## Documentation

--- a/src/bindings/wrap_field.cpp
+++ b/src/bindings/wrap_field.cpp
@@ -7,6 +7,11 @@
 #include "field.hpp"
 #include "wrappers.hpp"
 
+#ifdef _MSC_VER  
+  #include <BaseTsd.h>
+  typedef SSIZE_T ssize_t;
+#endif
+
 void wrap_field(py::module& m) {
   py::class_<Field>(m, "Field")
       .def_property_readonly("grid", &Field::grid)

--- a/src/bindings/wrap_voronoi.cpp
+++ b/src/bindings/wrap_voronoi.cpp
@@ -7,6 +7,10 @@
 #include "voronoi.hpp"
 #include "wrappers.hpp"
 
+#ifdef _MSC_VER  
+  #include <BaseTsd.h>
+  typedef SSIZE_T ssize_t;
+#endif
 
 void wrap_voronoi(py::module& m) {
     py::class_<VoronoiTessellator>(m, "VoronoiTessellator")

--- a/src/core/fieldops.cu
+++ b/src/core/fieldops.cu
@@ -310,7 +310,7 @@ Field operator*(const Field& a, const Field& x) {
 // --------------------------------------------------
 // fieldGetRGB
 
-const float pi = 3.1415926535897931f;
+__device__ const float pi = 3.1415926535897931f;
 
 /// Transform 3D vector with norm<=1 to its RGB representation
 __device__ real3 getRGB(real3 vec) {

--- a/src/core/inter_parameter.cu
+++ b/src/core/inter_parameter.cu
@@ -3,6 +3,7 @@
 #include "reduce.hpp"
 
 #include <algorithm>
+#include <string>
 
 InterParameter::InterParameter(std::shared_ptr<const System> system,
                                real value, std::string name, std::string unit)

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <stdexcept>
 #include <set>
+#include <string>
 
 #include "datatypes.hpp"
 #include "gpubuffer.hpp"

--- a/src/physics/CMakeLists.txt
+++ b/src/physics/CMakeLists.txt
@@ -102,3 +102,21 @@ target_link_libraries(physics PUBLIC core linsolver)
 
 link_directories(${CUDA_LIBRARY_DIR})
 target_link_libraries(physics PRIVATE cufft curand)
+
+
+# On Windows, the cufft and curand DLLs (also required by mumax³) are not found by default.
+# Therefore, we look for them in the installed NVIDIA CUDA Toolkit and copy them next to the .pyd.
+if (WIN32)
+    find_package(CUDAToolkit REQUIRED)
+
+    file(GLOB CUDA_RUNTIME_DLLS
+        "${CUDAToolkit_BIN_DIR}/cufft64_*.dll"
+        "${CUDAToolkit_BIN_DIR}/curand64_*.dll"
+    )
+
+    add_custom_command(TARGET physics POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${CUDA_RUNTIME_DLLS}
+            $<TARGET_FILE_DIR:_mumaxpluscpp>
+    )
+endif()


### PR DESCRIPTION
Thanks to the insight of @jplauzie in issue #93 (most importantly, the mysterious missing DLLs turned out to be `cufft64_*.dll` and `curand64_*.dll`), compilation on Windows should now be possible without users having to edit the source code before compiling.

More specifically, this PR implements points 1, 2, 3 and 5 of issue #93. Suggestion 4 (about linker warnings) was skipped for now, since the warning is not a fatal error, and fixing them breaks the compilation process for me.

I also updated the relevant `README.md` section concerning compilation on Windows. It seems the commands to be used are now mostly identical for both Linux and Windows, so a simplification of `README.md` remains possible.

$$\rightarrow$$ Could the reviewers check whether this branch still successfully compiles on Linux systems?