### PR TITLE
Add google analytics

### DIFF
--- a/docs/_static/google-analytics.js
+++ b/docs/_static/google-analytics.js
@@ -1,0 +1,5 @@
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+
+gtag('config', 'G-YEPT1QRBRH');

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,6 +78,11 @@ html_title = "mumax⁺"
 html_static_path = ['_static']
 html_css_files = ['logo.css', 'custom.css']
 
+html_js_files = [
+    ('https://www.googletagmanager.com/gtag/js?id=G-YEPT1QRBRH', {'async': 'async'}),
+    'google-analytics.js',  # a local file you create below
+]
+
 html_favicon = "_static/nimble-plus.png"
 
 rst_epilog = """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,7 +80,7 @@ html_css_files = ['logo.css', 'custom.css']
 
 html_js_files = [
     ('https://www.googletagmanager.com/gtag/js?id=G-YEPT1QRBRH', {'async': 'async'}),
-    'google-analytics.js',  # a local file you create below
+    'google-analytics.js',
 ]
 
 html_favicon = "_static/nimble-plus.png"


### PR DESCRIPTION
This adds a tracking method for google analytics on our website, so we can see the traffic. Because that is fun.
The added code in config.py gives the command to include the code in google-analytics.js in all of our webpages and that code sends data to google-analytics. That way we can see which pages were visited, when, from what type of device/browser, the country of origin, and how they got to the page. More information on the data privacy and security of google-analytics can be found [here](https://support.google.com/analytics/topic/2919631?hl=en&ref_topic=1008008,3544742,2986333,&sjid=10231154189361746692-NC).