### PR TITLE
Fix bug of minor bug fix in homogeneous AFM exchange calculation

### DIFF
--- a/src/physics/afmexchange.cu
+++ b/src/physics/afmexchange.cu
@@ -50,8 +50,11 @@ __global__ void k_afmExchangeFieldSite(CuField hField,
         hField.setVectorInCell(idx, real3{0, 0, 0});
       return;
     }
-    if (msat.valueAt(idx) == 0. || msat2.valueAt(idx) == 0.) {
+    if (msat.valueAt(idx) == 0.) {  // total field is 0
       hField.setVectorInCell(idx, real3{0, 0, 0});
+      return;
+    }
+    if (msat2.valueAt(idx) == 0.) {  // no addition to the field
       return;
     }
 


### PR DESCRIPTION
The whole field was set to 0 when only 1 of the 3 sublattices did not contribute. The two checks are now split up. Thank goodness for tests...