### PR TITLE
Fix #104: Look for DLLs in /x64 sudirectory

### DIFF
--- a/src/physics/CMakeLists.txt
+++ b/src/physics/CMakeLists.txt
@@ -112,11 +112,23 @@ if (WIN32)
     file(GLOB CUDA_RUNTIME_DLLS
         "${CUDAToolkit_BIN_DIR}/cufft64_*.dll"
         "${CUDAToolkit_BIN_DIR}/curand64_*.dll"
-    )
+        "${CUDAToolkit_BIN_DIR}/x64/cufft64_*.dll"
+        "${CUDAToolkit_BIN_DIR}/x64/curand64_*.dll"
+    ) # CUDA 13.0 and higher puts them below the /x64 directory.
 
-    add_custom_command(TARGET physics POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            ${CUDA_RUNTIME_DLLS}
-            $<TARGET_FILE_DIR:_mumaxpluscpp>
-    )
+    message(STATUS "CUDAToolkit_BIN_DIR=${CUDAToolkit_BIN_DIR}")
+    message(STATUS "CUDA_RUNTIME_DLLS=${CUDA_RUNTIME_DLLS}")
+
+    if (CUDA_RUNTIME_DLLS)
+        foreach(dll IN LISTS CUDA_RUNTIME_DLLS)
+            get_filename_component(dllname "${dll}" NAME)
+            add_custom_command(TARGET physics POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    "${dll}"
+                    "$<TARGET_FILE_DIR:_mumaxpluscpp>/${dllname}"
+            )
+        endforeach()
+    else()
+        message(WARNING "No CUDA cufft and curand DLLs found in ${CUDAToolkit_BIN_DIR}")
+    endif()
 endif()


### PR DESCRIPTION
This PR should fix issue #104 by searching for the `curand` and `cufft` DLLs in the correct location, which was changed in CUDA 13.0.

Some strange unrelated errors prevented me from testing this change before the holidays, but today compiling in the "Developer Powershell for VS 2022" seems to have somehow fixed those ¯\\\_(ツ)_/¯