### PR TITLE
Fix #111: Voronoi tessellation repeats along x-axis on Windows

### DIFF
--- a/src/core/voronoi.cpp
+++ b/src/core/voronoi.cpp
@@ -120,9 +120,9 @@ std::vector<Center> VoronoiTessellator::centersInTile(const int3 pos) {
         return it->second.centers;
     }
 
-    const int64_t seed = ((int64_t(pos.x) + (1LL << 20)) * (1LL << 40)) +
-                         ((int64_t(pos.y) + (1LL << 20)) * (1LL << 20)) +
-                         ( int64_t(pos.z) + (1LL << 20));
+    const int32_t seed = ((int32_t(pos.x) + (1LL << 10)) * (1LL << 20)) +
+                         ((int32_t(pos.y) + (1LL << 10)) * (1LL << 10)) +
+                         ( int32_t(pos.z) + (1LL << 10));
 
     engine_.seed (seed ^ seed_);
     int N = Poisson(lambda_);

--- a/src/core/voronoi.cpp
+++ b/src/core/voronoi.cpp
@@ -124,7 +124,7 @@ std::vector<Center> VoronoiTessellator::centersInTile(const int3 pos) {
                          ((int32_t(pos.y) + (1LL << 10)) * (1LL << 10)) +
                          ( int32_t(pos.z) + (1LL << 10));
 
-    engine_.seed (seed ^ seed_);
+    engine_.seed(seed ^ seed_);
     int N = Poisson(lambda_);
     std::vector<Center> centers(N);
 


### PR DESCRIPTION
As reported in #111, the Voronoi tessellation exhibited periodicity along the x-axis on Windows.
**The culprit is `engine_.seed(seed ^ seed_);`** on line 127 in `src/core/voronoi.cpp`.

### Cause
The Voronoi tessellation uses "tiles" for efficiency: the RNG generates some Voronoi centres in each of these. The seed for this RNG is based on the `(x,y,z)`-index of the current tile: it was a 64-bit number constructed by taking the last 24 bits of the x-index, the last 20 bits of the y-index, and the last 20 bits of the z-index. The issue was that the argument of `engine_.seed(...)` has a different data type in Windows than on Linux:

- MSVC's default RNG is `std::mt19937`, seeded using an `unsigned int`,
- GCC's default RNG is `std::minstd_rand0`, seeded using a `uint_fast32_t`.

Somehow, passing a 64-bit seed on MSVC cuts off the first 32 bits, while on GCC the 64-bit number stays intact. Hence, on Windows, the x-index of the tile was completely disregarded, explaining the periodicity along x.

### Fix
The seed was changed to a 32-bit integer consisting of 12 x-, 10 y-, and 10 z-bits. Hence, the periodicity now occurs over a length scale of &gtrapprox;2048 Voronoi cells, rather than 2 as was the case for the x-axis. I believe this should suffice for all but the most extreme simulations.