### PR TITLE
Set `Variable` value per region

### DIFF
--- a/mumaxplus/variable.py
+++ b/mumaxplus/variable.py
@@ -27,6 +27,15 @@ class Variable(FieldQuantity):
         else:
             self._impl.set(value)
 
+    def set_in_region(self, region_idx, value):
+        """
+        Set a uniform, static value in a specified region.
+        """
+        assert (isinstance(value, (float, int)) or
+            (isinstance(value, tuple) and len(value) == 3)
+            ), "The value should be uniform and static."
+        self._impl.set_in_region(region_idx, value)
+
     def _set_func(self, func):
         X, Y, Z = self.meshgrid
         self._impl.set(_np.vectorize(func, otypes=[float]*self.shape[0])(X, Y, Z))

--- a/src/bindings/wrap_variable.cpp
+++ b/src/bindings/wrap_variable.cpp
@@ -12,5 +12,11 @@ void wrap_variable(py::module& m) {
         Field tmp(v->system(), v->ncomp());
         setArrayInField(tmp, data);
         v->set(std::move(tmp));
+      })
+      .def("set_in_region", [](const Variable* v, unsigned int idx, real value) {
+                                v->setInRegion(idx, value);
+      })
+      .def("set_in_region", [](const Variable* v, unsigned int idx, real3 value) {
+                                v->setInRegion(idx, value);
       });
 }

--- a/src/core/variable.cpp
+++ b/src/core/variable.cpp
@@ -67,6 +67,21 @@ void Variable::set(real3 value) const {
   field_->setUniformComponent(2, value.z);
 }
 
+void Variable::setInRegion(const unsigned int region_idx, real value) const {
+  if (ncomp() != 1)
+    throw std::runtime_error("Variable has " + std::to_string(ncomp()) +
+                             "components instead of 1");
+  field_->setUniformComponentInRegion(region_idx, 0, value);
+}
+
+void Variable::setInRegion(const unsigned int region_idx, real3 value) const {
+  if (ncomp() != 3)
+    throw std::runtime_error("Variable has " + std::to_string(ncomp()) +
+                             "components instead of 3");
+  field_->setUniformValueInRegion(region_idx, value);
+}
+
+
 NormalizedVariable::NormalizedVariable(std::shared_ptr<const System> system,
                                        int ncomp,
                                        std::string name,
@@ -84,4 +99,12 @@ void NormalizedVariable::set(real value) const {
 
 void NormalizedVariable::set(real3 value) const {
   Variable::set(normalized(value));
+}
+
+void NormalizedVariable::setInRegion(const unsigned int region_idx, real value) const {
+  Variable::setInRegion(region_idx, 1);
+}
+
+void NormalizedVariable::setInRegion(const unsigned int region_idx, real3 value) const {
+  Variable::setInRegion(region_idx, normalized(value));
 }

--- a/src/core/variable.hpp
+++ b/src/core/variable.hpp
@@ -27,6 +27,8 @@ class Variable : public FieldQuantity {
   virtual void set(const Field&) const;
   virtual void set(real) const;
   virtual void set(real3) const;
+  virtual void setInRegion(const unsigned int, real) const;
+  virtual void setInRegion(const unsigned int, real3) const;
 
   // Assignment operators which call the respective set function
   void operator=(const Field& f) const { set(f); }
@@ -50,4 +52,6 @@ class NormalizedVariable : public Variable {
   void set(const Field&) const;
   void set(real) const;
   void set(real3) const;
+  void setInRegion(const unsigned int, real) const;
+  void setInRegion(const unsigned int, real3) const;
 };


### PR DESCRIPTION
This PR allows for region-wise setting of `Variable` values (as was already possible for `(Vector)Parameter`). This partially answers the request in issue #117 .
**Note:** the possibility to use a function or array to set a non-uniform and/or dynamic value per region is **not included here**. This is a more general `Field`-related issue and will be taken care of later in a separate PR.