### PR TITLE
Feature: Use a function to set `Parameter` and `Variable` values in a single region

### DIFF
--- a/mumaxplus/parameter.py
+++ b/mumaxplus/parameter.py
@@ -214,7 +214,7 @@ class Parameter(FieldQuantity):
 
         # uniform value
         if isinstance(value, (float, int)) or (
-           isinstance(value, tuple) and len(value) == 3):
+           (isinstance(value, tuple) or isinstance(value, _np.ndarray)) and len(value) == 3):
             self._impl.set_in_region(region_idx, value)
 
         # evaluate value based on function

--- a/mumaxplus/parameter.py
+++ b/mumaxplus/parameter.py
@@ -169,6 +169,10 @@ class Parameter(FieldQuantity):
         ----------
         value: float, tuple of floats, numpy array, or callable
             The new value for the parameter.
+
+        See Also
+        --------
+        :func:`set_in_region`
         """
         self._reset_fields_default()
 
@@ -192,12 +196,50 @@ class Parameter(FieldQuantity):
 
     def set_in_region(self, region_idx, value):
         """
-        Set a uniform, static value in a specified region.
+        Set a static parameter value in a specified region.
+
+        Parameters
+        ----------
+        region_idx : int
+            The index of the region the parameter must be set in.
+        value : float, tuple of floats, or callable
+            Value to assign within the specified region. The value may be either a
+            uniform scalar or vector matching the number of parameter components, or
+            a callable that takes grid coordinates and returns a compatible value.
+
+        See Also
+        --------
+        :func:`set`
         """
-        assert (isinstance(value, (float, int)) or
-            (isinstance(value, tuple) and len(value) == 3)
-            ), "The value should be uniform and static."
-        self._impl.set_in_region(region_idx, value)
+
+        # uniform value
+        if isinstance(value, (float, int)) or (
+           isinstance(value, tuple) and len(value) == 3):
+            self._impl.set_in_region(region_idx, value)
+
+        # evaluate value based on function
+        elif callable(value):
+            regions = self._impl.system.regions
+            mask = (regions == region_idx)
+            x, y, z = self.meshgrid
+
+            field = self.eval().copy()
+            data = value(x[mask], y[mask], z[mask])
+
+            if self.ncomp == 1:
+                if isinstance(data, (tuple, list)):
+                    raise ValueError("Function must return a scalar value.")
+                field[0][mask] = data
+            else:
+                if len(data) != self.ncomp:
+                    raise ValueError(f"Function must return values with {self.ncomp} components, "+
+                                     f"got {len(data)} instead.")
+                for c in range(self.ncomp):
+                    field[c][mask] = data[c]
+            self._impl.set(field)
+
+        else:
+            raise TypeError("Value must be uniform or returned by a function.")
 
     def _set_func(self, func):
         X, Y, Z = self.meshgrid

--- a/mumaxplus/variable.py
+++ b/mumaxplus/variable.py
@@ -21,6 +21,10 @@ class Variable(FieldQuantity):
             Or the new value can be set cell by cell with an ndarray with the same
             shape as this variable, or with a function which returns the cell value
             as a function of the position.
+
+        See Also
+        --------
+        :func:`set_in_region`
         """
         if hasattr(value, "__call__"):
             self._set_func(value)

--- a/mumaxplus/variable.py
+++ b/mumaxplus/variable.py
@@ -47,7 +47,7 @@ class Variable(FieldQuantity):
 
         # uniform value
         if isinstance(value, (float, int)) or (
-           isinstance(value, tuple) and len(value) == 3):
+           (isinstance(value, tuple) or isinstance(value, _np.ndarray)) and len(value) == 3):
             self._impl.set_in_region(region_idx, value)
 
         # evaluate value based on function

--- a/mumaxplus/variable.py
+++ b/mumaxplus/variable.py
@@ -27,6 +27,53 @@ class Variable(FieldQuantity):
         else:
             self._impl.set(value)
 
+    def set_in_region(self, region_idx, value):
+        """
+        Set a static value in a specified region.
+
+        Parameters
+        ----------
+        region_idx : int
+            The index of the region the variable must be set in.
+        value : float, tuple of floats, or callable
+            Value to assign within the specified region. The value may be either a
+            uniform scalar or vector matching the number of variable components, or
+            a callable that takes grid coordinates and returns a compatible value.
+
+        See Also
+        --------
+        :func:`set`
+        """
+
+        # uniform value
+        if isinstance(value, (float, int)) or (
+           isinstance(value, tuple) and len(value) == 3):
+            self._impl.set_in_region(region_idx, value)
+
+        # evaluate value based on function
+        elif callable(value):
+            regions = self._impl.system.regions
+            mask = (regions == region_idx)
+            x, y, z = self.meshgrid
+
+            field = self.eval().copy()
+            data = value(x[mask], y[mask], z[mask])
+
+            if self.ncomp == 1:
+                if isinstance(data, (tuple, list)):
+                    raise ValueError("Function must return a scalar value.")
+                field[0][mask] = data
+            else:
+                if len(data) != self.ncomp:
+                    raise ValueError(f"Function must return values with {self.ncomp} components, "+
+                                     f"got {len(data)} instead.")
+                for c in range(self.ncomp):
+                    field[c][mask] = data[c]
+            self._impl.set(field)
+
+        else:
+            raise TypeError("Value must be uniform or returned by a function.")
+
     def _set_func(self, func):
         X, Y, Z = self.meshgrid
         self._impl.set(_np.vectorize(func, otypes=[float]*self.shape[0])(X, Y, Z))

--- a/test/test_set_in_region.py
+++ b/test/test_set_in_region.py
@@ -1,0 +1,156 @@
+from typing import Tuple
+
+import numpy as np
+import pytest
+
+from mumaxplus import Ferromagnet, Grid, World
+
+@pytest.fixture
+def test_parameters() -> Tuple[Ferromagnet, np.ndarray]:
+    nx, ny, nz = 4, 7, 3
+    w = World(cellsize=(1e-9, 1e-9, 1e-9))
+    g = Grid((nx, ny, nz))
+    r = np.random.randint(0, 12345, size=g.shape)
+    magnet = Ferromagnet(w, g, regions=r)
+    return magnet, r
+
+def test_uniform_parameter_in_region(test_parameters: Tuple[Ferromagnet, np.ndarray]):
+    magnet, regions = test_parameters
+    ku1_value = 1e6
+
+    some_index = np.random.choice(np.unique(regions))
+    magnet.ku1.set_in_region(some_index, ku1_value)
+
+    mask = regions == some_index
+    assert np.all(magnet.ku1()[0, mask] == ku1_value)
+    assert np.all(magnet.ku1()[0, ~mask] == 0.0)
+
+def test_uniform_vectorparameter_in_region(test_parameters: Tuple[Ferromagnet, np.ndarray]):
+    magnet, regions = test_parameters
+    bias_value = np.array((1, 0.1, 3))
+
+    some_index = np.random.choice(np.unique(regions))
+    magnet.bias_magnetic_field.set_in_region(some_index, bias_value)
+
+    mask = regions == some_index
+    assert np.allclose(magnet.bias_magnetic_field()[:, mask], bias_value[:, None])
+    assert np.all(magnet.bias_magnetic_field()[:, ~mask] == 0.0)
+
+def test_uniform_variable_in_region(test_parameters: Tuple[Ferromagnet, np.ndarray]):
+    magnet, regions = test_parameters
+
+    initial_vector = np.array((1, 0, 0))
+    region_value = np.array((0, 1, 0))
+
+    magnet.magnetization = initial_vector
+
+    some_index = np.random.choice(np.unique(regions))
+    magnet.magnetization.set_in_region(some_index, region_value)
+
+    mask = regions == some_index
+    assert np.allclose(magnet.magnetization()[:, mask], region_value[:, None])
+    assert np.allclose(magnet.magnetization()[:, ~mask], initial_vector[:, None])
+
+def test_functional_parameter_in_region(test_parameters: Tuple[Ferromagnet, np.ndarray]):
+    magnet, regions = test_parameters
+
+    def func(x, y, z):
+        return x + y + z
+
+    some_index = np.random.choice(np.unique(regions))
+    magnet.ku1.set_in_region(some_index, func)
+
+    x, y, z = magnet.ku1.meshgrid
+    mask = regions == some_index
+
+    assert np.allclose(magnet.ku1()[0, mask], func(x[mask], y[mask], z[mask]))
+    assert np.all(magnet.ku1()[0, ~mask] == 0.0)
+
+def test_functional_vectorparameter_in_region(test_parameters: Tuple[Ferromagnet, np.ndarray]):
+    magnet, regions = test_parameters
+
+    def func(x, y, z):
+        return (x, y**2, 3*x)
+
+    some_index = np.random.choice(np.unique(regions))
+    magnet.bias_magnetic_field.set_in_region(some_index, func)
+
+    x, y, z = magnet.bias_magnetic_field.meshgrid
+    mask = regions == some_index
+
+    assert np.allclose(magnet.bias_magnetic_field()[:, mask],
+                       np.array(func(x[mask], y[mask], z[mask]))[:, None])
+    assert np.all(magnet.bias_magnetic_field()[:, ~mask] == 0.0)
+
+def test_functional_variable_in_region(test_parameters: Tuple[Ferromagnet, np.ndarray]):
+    magnet, regions = test_parameters
+
+    def func(x, y, z):
+        vec = np.array((x, y**2, z + 3e-9))
+        return vec / np.linalg.norm(vec, axis=0)
+
+    initial_vector = np.array((1.0, 0.0, 0.0))
+    magnet.magnetization = initial_vector
+
+    some_index = np.random.choice(np.unique(regions))
+    magnet.magnetization.set_in_region(some_index, func)
+
+    x, y, z = magnet.magnetization.meshgrid
+    mask = regions == some_index
+
+    assert np.allclose(magnet.magnetization()[:, mask], func(x[mask], y[mask], z[mask]))
+    assert np.all(magnet.magnetization()[:, ~mask] == initial_vector[:,None])
+
+def test_incompatible_uniform_value_in_region_scalar_parameter(test_parameters):
+    magnet, regions = test_parameters
+    some_index = np.random.choice(np.unique(regions))
+
+    with pytest.raises(TypeError):
+        magnet.ku1.set_in_region(some_index, (1.0, 2.0))
+
+def test_incompatible_uniform_value_in_region_vector_parameter(test_parameters):
+    magnet, regions = test_parameters
+    some_index = np.random.choice(np.unique(regions))
+
+    with pytest.raises(TypeError):
+        magnet.bias_magnetic_field.set_in_region(some_index, (1.0, 2.0))
+
+def test_incompatible_uniform_value_in_region_variable(test_parameters):
+    magnet, regions = test_parameters
+    some_index = np.random.choice(np.unique(regions))
+
+    with pytest.raises(TypeError):
+        magnet.magnetization.set_in_region(some_index, (2.0, 2.0))
+
+def test_incompatible_function_in_region_scalar_parameter(test_parameters):
+    magnet, regions = test_parameters
+
+    def bad_func(x, y, z):
+        return (x, y)
+
+    some_index = np.random.choice(np.unique(regions))
+
+    with pytest.raises(ValueError):
+        magnet.ku1.set_in_region(some_index, bad_func)
+
+def test_incompatible_function_in_region_vector_parameter(test_parameters):
+    magnet, regions = test_parameters
+
+    def bad_func(x, y, z):
+        return (x, y)
+
+    some_index = np.random.choice(np.unique(regions))
+
+    with pytest.raises(ValueError):
+        magnet.bias_magnetic_field.set_in_region(some_index, bad_func)
+
+def test_incompatible_function_in_region_variable(test_parameters):
+    magnet, regions = test_parameters
+
+    def bad_func(x, y, z):
+        return (x, y)
+
+    some_index = np.random.choice(np.unique(regions))
+
+    with pytest.raises(ValueError):
+        magnet.magnetization.set_in_region(some_index, bad_func)


### PR DESCRIPTION
This PR answers to the request in issue #117 (complementary to PR #121), allowing for the use of functions to set static values in `Parameter` and `Variable` regions.