### PR TITLE
Add option to avoid storing timesolver.solve data in RAM

### DIFF
--- a/mumaxplus/timesolver.py
+++ b/mumaxplus/timesolver.py
@@ -20,7 +20,8 @@ class TimeSolverOutput:
             Specify wether to store the data in an output dictionary.
         """
         self._quantities = quantity_dict
-        self._data = {"time": []}
+        self._values = {}  # dictionary to keep calculated quantities of one step
+        self._data = {"time": []}  # dict to keep all data
         for key in self._quantities.keys():
             self._data[key] = []
 
@@ -42,19 +43,19 @@ class TimeSolverOutput:
         """Compute all the specified quantities for the current state."""
 
         # Compute values
-        values = {"time": time}
+        self._values["time"] = time
         for key, func in self._quantities.items():
-            values[key] = func()
+            self._values[key] = func()
 
         # Store in memory
         if self._store_as_dict:
-            for key, value in values.items():
+            for key, value in self._values.items():
                 self._data[key].append(value)
 
         # Write to file
         if self._file_name is not None:
             with open(self._file_name, 'a') as file:
-                print(*[values[key] for key in self._keys], sep="\t", file=file)
+                print(*[self._values[key] for key in self._keys], sep="\t", file=file)
 
     def __getitem__(self, key):
         """Return the computed values of a quantity."""

--- a/mumaxplus/timesolver.py
+++ b/mumaxplus/timesolver.py
@@ -2,10 +2,11 @@
 
 from typing import Callable
 import os as _os
+import warnings
 from tqdm import tqdm as _tqdm
 
 class TimeSolverOutput:
-    def __init__(self, quantity_dict, file_name=None):
+    def __init__(self, quantity_dict, file_name=None, store_data=True):
         """Collect values of a list of quantities on specified timepoints.
 
         Parameters
@@ -15,6 +16,8 @@ class TimeSolverOutput:
         file_name : str, optional
             Optional name of an output file, in which the data is also written as
             tab-separated values.
+        store_data : bool (default=True)
+            Specify wether to store the data in `quantity_dict`.
         """
         self._quantities = quantity_dict
         self._data = {"time": []}
@@ -23,6 +26,12 @@ class TimeSolverOutput:
 
         self._keys = list(self._data.keys())  # keep list of keys to maintain order
         self._file_name = file_name
+        self._store_data = store_data
+
+        if self._file_name is None and self._store_data is False:
+            warnings.warn("The timesolver output will not be saved or stored if `file_name` "
+            "is not specified and `store_data` is set to `False`.")
+
         if self._file_name is not None:
             if directory := _os.path.dirname(self._file_name):
                 _os.makedirs(directory, exist_ok=True)
@@ -31,14 +40,21 @@ class TimeSolverOutput:
 
     def write_line(self, time):
         """Compute all the specified quantities for the current state."""
-        self._data["time"].append(time)
-        for key, func in self._quantities.items():
-            self._data[key].append(func())
 
-        # write all latest data to a new line in file
+        # Compute values
+        values = {"time": time}
+        for key, func in self._quantities.items():
+            values[key] = func()
+
+        # Store in memory
+        if self._store_data:
+            for key, value in values.items():
+                self._data[key].append(value)
+
+        # Write to file
         if self._file_name is not None:
             with open(self._file_name, 'a') as file:
-                print(*[self._data[key][-1] for key in self._keys], sep="\t", file=file)
+                print(*[values[key] for key in self._keys], sep="\t", file=file)
 
     def __getitem__(self, key):
         """Return the computed values of a quantity."""
@@ -111,7 +127,7 @@ class TimeSolver:
         self._assure_sensible_timestep()
         self._impl.run(duration)
 
-    def solve(self, timepoints, quantity_dict, file_name=None, tqdm=False) -> TimeSolverOutput:
+    def solve(self, timepoints, quantity_dict, file_name=None, store_data=True, tqdm=False) -> TimeSolverOutput:
         """Solve the differential equation.
 
         The functions collects values of a list of specified quantities
@@ -126,6 +142,8 @@ class TimeSolver:
         file_name : str, optional
             Optional name of an output file, in which the data is also written
             as tab-separated values during the simulation.
+        store_data : bool (default=True)
+            Specify wether to store the calculated quantities in `quantity_dict`.
         tqdm : bool (default=False)
             Prints tqdm progress bar if set to True.
 
@@ -133,13 +151,14 @@ class TimeSolver:
         -------
         output : TimeSolverOutput
             Collected values of specified quantities at specified timepoints.
+            If store_data=True, this returns an empty dictionary.
         """
         # check if time points are increasing and lie in the future
         assert all(i1 <= i2 for i1, i2 in zip(timepoints, timepoints[1:])), "The list of timepoints should be increasing."
         assert self.time <= timepoints[0], "The list of timepoints should lie in the future."
 
         self._assure_sensible_timestep()
-        output = TimeSolverOutput(quantity_dict, file_name)
+        output = TimeSolverOutput(quantity_dict, file_name, store_data)
 
         if tqdm: timepoints = _tqdm(timepoints)
         for tp in timepoints:

--- a/mumaxplus/timesolver.py
+++ b/mumaxplus/timesolver.py
@@ -6,7 +6,7 @@ import warnings
 from tqdm import tqdm as _tqdm
 
 class TimeSolverOutput:
-    def __init__(self, quantity_dict, file_name=None, store_data=True):
+    def __init__(self, quantity_dict, file_name=None, store_as_dict=True):
         """Collect values of a list of quantities on specified timepoints.
 
         Parameters
@@ -16,8 +16,8 @@ class TimeSolverOutput:
         file_name : str, optional
             Optional name of an output file, in which the data is also written as
             tab-separated values.
-        store_data : bool (default=True)
-            Specify wether to store the data in `quantity_dict`.
+        store_as_dict : bool (default=True)
+            Specify wether to store the data in an output dictionary.
         """
         self._quantities = quantity_dict
         self._data = {"time": []}
@@ -26,11 +26,11 @@ class TimeSolverOutput:
 
         self._keys = list(self._data.keys())  # keep list of keys to maintain order
         self._file_name = file_name
-        self._store_data = store_data
+        self._store_as_dict = store_as_dict
 
-        if self._file_name is None and self._store_data is False:
+        if self._file_name is None and self._store_as_dict is False:
             warnings.warn("The timesolver output will not be saved or stored if `file_name` "
-            "is not specified and `store_data` is set to `False`.")
+            "is not specified and `store_as_dict` is set to `False`. Consider using `run()` instead.")
 
         if self._file_name is not None:
             if directory := _os.path.dirname(self._file_name):
@@ -47,7 +47,7 @@ class TimeSolverOutput:
             values[key] = func()
 
         # Store in memory
-        if self._store_data:
+        if self._store_as_dict:
             for key, value in values.items():
                 self._data[key].append(value)
 
@@ -127,7 +127,7 @@ class TimeSolver:
         self._assure_sensible_timestep()
         self._impl.run(duration)
 
-    def solve(self, timepoints, quantity_dict, file_name=None, store_data=True, tqdm=False) -> TimeSolverOutput:
+    def solve(self, timepoints, quantity_dict, file_name=None, store_as_dict=True, tqdm=False) -> TimeSolverOutput:
         """Solve the differential equation.
 
         The functions collects values of a list of specified quantities
@@ -142,8 +142,8 @@ class TimeSolver:
         file_name : str, optional
             Optional name of an output file, in which the data is also written
             as tab-separated values during the simulation.
-        store_data : bool (default=True)
-            Specify wether to store the calculated quantities in `quantity_dict`.
+        store_as_dict : bool (default=True)
+            Specify whether to store the evaluated quantities in an output dictionary.
         tqdm : bool (default=False)
             Prints tqdm progress bar if set to True.
 
@@ -151,14 +151,14 @@ class TimeSolver:
         -------
         output : TimeSolverOutput
             Collected values of specified quantities at specified timepoints.
-            If store_data=True, this returns an empty dictionary.
+            If store_as_dict=False, this returns None.
         """
         # check if time points are increasing and lie in the future
         assert all(i1 <= i2 for i1, i2 in zip(timepoints, timepoints[1:])), "The list of timepoints should be increasing."
         assert self.time <= timepoints[0], "The list of timepoints should lie in the future."
 
         self._assure_sensible_timestep()
-        output = TimeSolverOutput(quantity_dict, file_name, store_data)
+        output = TimeSolverOutput(quantity_dict, file_name, store_as_dict)
 
         if tqdm: timepoints = _tqdm(timepoints)
         for tp in timepoints:
@@ -168,7 +168,8 @@ class TimeSolver:
             self._impl.run(duration)
 
             output.write_line(self.time)
-        return output
+        if store_as_dict:
+            return output
 
     @property
     def timestep(self) -> float:


### PR DESCRIPTION
This is a follow-up pull request after PR #55.