### PR TITLE
Fix #138: DMI values are taken from origin

### DIFF
--- a/src/core/parameter.hpp
+++ b/src/core/parameter.hpp
@@ -106,7 +106,7 @@ __device__ inline real CuParameter::valueAt(int3 coo) const {
 
 __device__ inline real CuParameter::harmonicMean(int idx1, int idx2) const {
   if (idx1 == idx2) { return valueAt(idx1); }
-  else { return harmonicMean(valueAt(idx1), valueAt(idx2)); }
+  else { return ::harmonicMean(valueAt(idx1), valueAt(idx2)); }
 }
 
 


### PR DESCRIPTION
The bug is reported and described in #138. The `harmonicMean` member function of `CuParameter` was called recursively, thus casting the real parameter values into `int`s (zeros), returning the value (during the second call) at grid index zero, which is the origin.
This is fixed by bypassing this member function and forcing to look inside the global namespace only.