### PR TITLE
Add ovf functions and tests

### DIFF
--- a/mumaxplus/fieldquantity.py
+++ b/mumaxplus/fieldquantity.py
@@ -3,6 +3,7 @@
 import numpy as _np
 import pyovf
 from .grid import Grid
+from pathlib import Path
 
 
 class FieldQuantity:
@@ -156,11 +157,12 @@ class FieldQuantity:
         name : str (default="")
             The name of the OVF file. If the name is empty (the default), it will look for the most recently saved file with this FieldQuantity name."""
         if name == "":
-            if self.name not in self._ovf_counts:
-                raise FileNotFoundError(f"{self.name.replace(":", "_") + f"{0:06d}.ovf"} does not exist")
-            count = self._ovf_counts[self.name] - 1
-            name = self.name.replace(":", "_") + f"{count:06d}.ovf"
-
+            name_replace = self.name.replace(":", "_")
+            files = Path(".").glob(f"{name_replace}*.ovf")
+            try:
+                name = str(max(files, key=lambda f: int(f.stem[-6:])))
+            except ValueError:
+                raise FileNotFoundError(F"No files matching '{name_replace}*.ovf' found.")
         ovf = pyovf.read(name)
         if self.ncomp == 1:
             data = _np.array([ovf.data])

--- a/mumaxplus/fieldquantity.py
+++ b/mumaxplus/fieldquantity.py
@@ -1,7 +1,7 @@
 """FieldQuantity implementation."""
 
 import numpy as _np
-
+import pyovf
 from .grid import Grid
 
 
@@ -122,3 +122,34 @@ class FieldQuantity:
             self._impl.exec()
         stop = time.time()
         return (stop - start) / ntimes
+
+    def save_ovf(self, name=""):
+        """Save the FieldQuantity as an OVF file.
+
+        Parameters
+        ----------
+        name : str (default="")
+            The name of the OVF file. If the name is empty (the default), the name of the FieldQuantity will be used.
+            
+        Warning
+        -------
+        The shape of the array in the OVF file is (nz, ny, nx, ncomp) and not (ncomp, nz, ny, nx) in order to have the correct metadata."""
+        cx, cy, cz = self._impl.system.cellsize
+        ovf = pyovf.create(_np.moveaxis(self.eval(), 0, -1), xstepsize=cx, ystepsize=cy, zstepsize=cz, title=self.name)
+        ovf.TotalSimTime = self._impl.system.time
+        if name == "":
+            name = self.name + ".ovf"
+        pyovf.write(name, ovf)
+
+    def load_ovf(self, name=""):
+        """Load an OVF file as a FieldQuantity.
+
+        Parameters
+        ----------
+        name : str (default="")
+            The name of the OVF file. If the name is empty (the default), the name of the FieldQuantity will be used."""
+        if name == "":
+            name = self.name + ".ovf"
+        ovf = pyovf.read(name)
+        data = _np.ascontiguousarray(_np.moveaxis(ovf.data, -1, 0))
+        self.set(data)

--- a/mumaxplus/fieldquantity.py
+++ b/mumaxplus/fieldquantity.py
@@ -151,5 +151,8 @@ class FieldQuantity:
         if name == "":
             name = self.name + ".ovf"
         ovf = pyovf.read(name)
-        data = _np.ascontiguousarray(_np.moveaxis(ovf.data, -1, 0))
+        if self.ncomp == 1:
+            data = _np.array([ovf.data])
+        else:
+            data = _np.ascontiguousarray(_np.moveaxis(ovf.data, -1, 0))
         self.set(data)

--- a/mumaxplus/fieldquantity.py
+++ b/mumaxplus/fieldquantity.py
@@ -145,7 +145,7 @@ class FieldQuantity:
         ovf.TotalSimTime = self._impl.system.time
         if name == "":
             count = self._ovf_counts.get(self.name, 0)
-            name = self.name.replace(":", "_") + f"{count:06d}.ovf"
+            name = self.name.replace(":", "_") + f"_{count:06d}.ovf"
             self._ovf_counts[self.name] = count + 1
         pyovf.write(name, ovf)
 
@@ -160,9 +160,9 @@ class FieldQuantity:
             name_replace = self.name.replace(":", "_")
             files = Path(".").glob(f"{name_replace}*.ovf")
             try:
-                name = str(max(files, key=lambda f: int(f.stem[-6:])))
+                name = str(max(filter(lambda f: f.stem[-6:].isnumeric(), files), key=lambda f: int(f.stem[-6:])))
             except ValueError:
-                raise FileNotFoundError(F"No files matching '{name_replace}*.ovf' found.")
+                raise FileNotFoundError(F"No files matching '_{name_replace}*.ovf' found.")
         ovf = pyovf.read(name)
         if self.ncomp == 1:
             data = _np.array([ovf.data])

--- a/mumaxplus/fieldquantity.py
+++ b/mumaxplus/fieldquantity.py
@@ -7,6 +7,7 @@ from .grid import Grid
 
 class FieldQuantity:
     """A functor representing a physical field quantity."""
+    _ovf_counts = {} # It keeps resetting to 0 if it is in the __init__
     def __init__(self, impl):
         self._impl = impl
 
@@ -133,23 +134,27 @@ class FieldQuantity:
             
         Warning
         -------
-        The shape of the array in the OVF file is (nz, ny, nx, ncomp) and not (ncomp, nz, ny, nx) in order to have the correct metadata."""
+        The shape of the array in the OVF file is (nz, ny, nx, ncomp) and not (ncomp, nz, ny, nx) in order to have the correct metadata.
+        
+        Warning
+        -------
+        self.name returns a string with colons (:). To avoid issues on Windows, these colons are changed to underscores (_)."""
         cx, cy, cz = self._impl.system.cellsize
         ovf = pyovf.create(_np.moveaxis(self.eval(), 0, -1), xstepsize=cx, ystepsize=cy, zstepsize=cz, title=self.name)
         ovf.TotalSimTime = self._impl.system.time
         if name == "":
-            name = self.name.replace(":", "_") + ".ovf"
+            count = self._ovf_counts.get(self.name, 0)
+            name = self.name.replace(":", "_") + f"{count:06d}.ovf"
+            self._ovf_counts[self.name] = count + 1
         pyovf.write(name, ovf)
 
-    def load_ovf(self, name=""):
+    def load_ovf(self, name):
         """Load an OVF file as a FieldQuantity.
 
         Parameters
         ----------
         name : str (default="")
-            The name of the OVF file. If the name is empty (the default), the name of the FieldQuantity will be used."""
-        if name == "":
-            name = self.name.replace(":", "_") + ".ovf"
+            The name of the OVF file."""
         ovf = pyovf.read(name)
         if self.ncomp == 1:
             data = _np.array([ovf.data])

--- a/mumaxplus/fieldquantity.py
+++ b/mumaxplus/fieldquantity.py
@@ -138,7 +138,7 @@ class FieldQuantity:
         ovf = pyovf.create(_np.moveaxis(self.eval(), 0, -1), xstepsize=cx, ystepsize=cy, zstepsize=cz, title=self.name)
         ovf.TotalSimTime = self._impl.system.time
         if name == "":
-            name = self.name + ".ovf"
+            name = self.name.replace(":", "_") + ".ovf"
         pyovf.write(name, ovf)
 
     def load_ovf(self, name=""):
@@ -149,10 +149,11 @@ class FieldQuantity:
         name : str (default="")
             The name of the OVF file. If the name is empty (the default), the name of the FieldQuantity will be used."""
         if name == "":
-            name = self.name + ".ovf"
+            name = self.name.replace(":", "_") + ".ovf"
         ovf = pyovf.read(name)
         if self.ncomp == 1:
             data = _np.array([ovf.data])
         else:
+            # _np.ascontiguousarray is used so data is the transformed array. Otherwise the C++ layer still uses ovf.data
             data = _np.ascontiguousarray(_np.moveaxis(ovf.data, -1, 0))
         self.set(data)

--- a/mumaxplus/fieldquantity.py
+++ b/mumaxplus/fieldquantity.py
@@ -130,7 +130,7 @@ class FieldQuantity:
         Parameters
         ----------
         name : str (default="")
-            The name of the OVF file. If the name is empty (the default), the name of the FieldQuantity will be used.
+            The name of the OVF file. If the name is empty (the default), the name of the FieldQuantity will be used appended with an integer of 6 digits.
             
         Warning
         -------
@@ -148,13 +148,19 @@ class FieldQuantity:
             self._ovf_counts[self.name] = count + 1
         pyovf.write(name, ovf)
 
-    def load_ovf(self, name):
+    def load_ovf(self, name=""):
         """Load an OVF file as a FieldQuantity.
 
         Parameters
         ----------
         name : str (default="")
-            The name of the OVF file."""
+            The name of the OVF file. If the name is empty (the default), it will look for the most recently saved file with this FieldQuantity name."""
+        if name == "":
+            if self.name not in self._ovf_counts:
+                raise FileNotFoundError(f"{self.name.replace(":", "_") + f"{0:06d}.ovf"} does not exist")
+            count = self._ovf_counts[self.name] - 1
+            name = self.name.replace(":", "_") + f"{count:06d}.ovf"
+
         ovf = pyovf.read(name)
         if self.ncomp == 1:
             data = _np.array([ovf.data])

--- a/mumaxplus/parameter.py
+++ b/mumaxplus/parameter.py
@@ -16,7 +16,7 @@ class Parameter(FieldQuantity):
         Parameters should only have to be initialized within the mumax⁺
         module and not by the end user.
         """
-        self._impl = impl
+        super().__init__(impl)
 
     def __repr__(self):
         """Return Parameter string representation."""

--- a/src/bindings/wrap_system.cpp
+++ b/src/bindings/wrap_system.cpp
@@ -40,6 +40,9 @@ py::array_t<T> get_data(const System* system, Getter getter, T default_value) {
 void wrap_system(py::module& m) {
   py::class_<System, std::shared_ptr<System>>(m, "System")
       .def_property_readonly("grid", &System::grid)
+      .def_property_readonly("time", [](const System& s) {
+                                     return s.world()->time();
+                                     })
       .def_property_readonly("cellsize", &System::cellsize)
       .def("cell_position", &System::cellPosition)
       .def_property_readonly("origin", &System::origin)

--- a/src/bindings/wrap_system.cpp
+++ b/src/bindings/wrap_system.cpp
@@ -40,9 +40,7 @@ py::array_t<T> get_data(const System* system, Getter getter, T default_value) {
 void wrap_system(py::module& m) {
   py::class_<System, std::shared_ptr<System>>(m, "System")
       .def_property_readonly("grid", &System::grid)
-      .def_property_readonly("time", [](const System& s) {
-                                     return s.world()->time();
-                                     })
+      .def_property_readonly("time", [](const System& s) {return s.world()->time();})
       .def_property_readonly("cellsize", &System::cellsize)
       .def("cell_position", &System::cellPosition)
       .def_property_readonly("origin", &System::origin)

--- a/test/test_ovf.py
+++ b/test/test_ovf.py
@@ -39,18 +39,18 @@ class TestOVF:
         self.magnet.strain_tensor.save_ovf()
 
         self.ovf_m = pyovf.read(self.name)
-        self.ovf_aex = pyovf.read(self.magnet.aex.name.replace(":", "_") + ".ovf")
-        self.ovf_strain = pyovf.read(self.magnet.strain_tensor.name.replace(":", "_") + ".ovf")
+        self.ovf_aex = pyovf.read(self.magnet.aex.name.replace(":", "_") + f"{0:06d}.ovf")
+        self.ovf_strain = pyovf.read(self.magnet.strain_tensor.name.replace(":", "_") + f"{0:06d}.ovf")
 
     def test_1D(self):
         self.magnet.aex = 1e-12 # Change aex
-        self.magnet.aex.load_ovf()
+        self.magnet.aex.load_ovf(self.magnet.aex.name.replace(":", "_") + f"{0:06d}.ovf")
         aex = self.magnet.aex.eval()
         assert max_relative_error(aex, self.aex) < RTOL
 
     def test_3D(self):
         self.magnet.magnetization = (0,0,1) # Change magnetization
-        self.magnet.magnetization.load_ovf()
+        self.magnet.magnetization.load_ovf(self.magnet.magnetization.name.replace(":", "_") + f"{0:06d}.ovf")
         mag = self.magnet.magnetization.eval()
         assert max_relative_error(mag, self.magnetization) < RTOL
 
@@ -59,7 +59,7 @@ class TestOVF:
         self.magnet.elastic_displacement = np.random.rand(3,nz,ny,nx)*1e-14 # Change strain_tensor
         strain = np.ascontiguousarray(np.moveaxis(self.ovf_strain.data, -1, 0))
         assert max_relative_error(strain, self.strain) < RTOL
-    
+
     def test_read_name(self):
         self.magnet.magnetization = (0,0,1) # Change magnetization
         self.magnet.magnetization.load_ovf(self.name)

--- a/test/test_ovf.py
+++ b/test/test_ovf.py
@@ -41,13 +41,13 @@ class TestOVF:
 
     def test_1D(self):
         self.magnet.aex = 1e-12 # Change aex
-        self.magnet.aex.load_ovf(self.magnet.aex.name.replace(":", "_") + f"{0:06d}.ovf")
+        self.magnet.aex.load_ovf()
         aex = self.magnet.aex.eval()
         assert max_relative_error(aex, self.aex) < RTOL
 
     def test_3D(self):
         self.magnet.magnetization = (0,0,1) # Change magnetization
-        self.magnet.magnetization.load_ovf(self.magnet.magnetization.name.replace(":", "_") + f"{0:06d}.ovf")
+        self.magnet.magnetization.load_ovf()
         mag = self.magnet.magnetization.eval()
         assert max_relative_error(mag, self.magnetization) < RTOL
 

--- a/test/test_ovf.py
+++ b/test/test_ovf.py
@@ -1,0 +1,56 @@
+from mumaxplus import *
+import pyovf
+import numpy as np
+from mumaxplus.util import plot_field
+
+RTOL = 2e-7
+
+def max_relative_error(result, wanted):
+    return np.max(np.abs(result - wanted) / np.abs(wanted))
+
+class TestOVF:
+    def setup_class(self):
+        self.name = "test.ovf"
+        cx, cy, cz = 4e-9, 2e-9, 5e-9
+        nx, ny, nz = 128, 32, 1
+
+        self.world = World(cellsize=(cx, cy, cz))
+
+        self.magnet = Ferromagnet(self.world, Grid((nx, ny, nz)))
+
+        self.magnet.magnetization = (1,0,0)
+        self.magnet.msat = 800e3
+        self.magnet.aex = 13e-12
+        self.magnet.alpha = 0.02
+
+        self.world.timesolver.run(0.5e-9)
+
+        self.magnetization = self.magnet.magnetization.eval()
+
+        self.magnet.magnetization.save_ovf(self.name)
+        self.magnet.magnetization.save_ovf()
+
+        self.ovf = pyovf.read(self.name)
+
+    def test_read(self):
+        self.magnet.magnetization.load_ovf()
+        mag = self.magnet.magnetization.eval()
+        assert max_relative_error(mag, self.magnetization) < RTOL
+    
+    def test_read_name(self):
+        self.magnet.magnetization.load_ovf(self.name)
+        mag = self.magnet.magnetization.eval()
+        assert max_relative_error(mag, self.magnetization) < RTOL
+
+    def test_size(self):
+        cx_ovf, cy_ovf, cz_ovf = self.ovf.xstepsize, self.ovf.ystepsize, self.ovf.zstepsize
+        cx, cy, cz = self.world.cellsize
+        assert max_relative_error(cx_ovf, cx) < RTOL and max_relative_error(cy_ovf, cy) < RTOL and max_relative_error(cz_ovf, cz) < RTOL
+
+    def test_grid(self):
+        nx_ovf, ny_ovf, nz_ovf = self.ovf.xnodes, self.ovf.ynodes, self.ovf.znodes
+        nx, ny, nz = self.magnet.grid.size
+        assert nx_ovf == nx and ny_ovf == ny and nz_ovf == nz
+
+    def test_title(self):
+        assert self.ovf.Title == self.magnet.magnetization.name

--- a/test/test_ovf.py
+++ b/test/test_ovf.py
@@ -1,4 +1,4 @@
-from mumaxplus import *
+from mumaxplus import World, Ferromagnet, Grid
 import pyovf
 import numpy as np
 
@@ -11,40 +11,57 @@ class TestOVF:
     def setup_class(self):
         self.name = "test.ovf"
         cx, cy, cz = 4e-9, 2e-9, 5e-9
-        nx, ny, nz = 128, 32, 1
+        nx, ny, nz = 32, 16, 8
 
         self.world = World(cellsize=(cx, cy, cz))
 
         self.magnet = Ferromagnet(self.world, Grid((nx, ny, nz)))
 
+        self.magnet.enable_elastodynamics = True
         self.magnet.magnetization = (1,0,0)
-        self.magnet.msat = 800e3
         self.magnet.aex = 13e-12
-        self.magnet.alpha = 0.02
+        self.magnet.elastic_displacement = np.random.rand(3,nz,ny,nx)*1e-14
 
         self.world.timesolver.run(0.5e-9)
 
         self.magnetization = self.magnet.magnetization.eval()
         self.aex = self.magnet.aex.eval()
-        print()
+        self.strain = self.magnet.strain_tensor.eval()
 
-        self.magnet.magnetization.save_ovf(self.name)
-        self.magnet.magnetization.save_ovf()
-
+        # Save 1D FieldQuantity
         self.magnet.aex.save_ovf()
 
-        self.ovf_m = pyovf.read(self.name)
-        self.ovf_aex = pyovf.read(self.magnet.aex.name + ".ovf")
+        # Save 3D FieldQuantity
+        self.magnet.magnetization.save_ovf(self.name)
+        self.magnet.magnetization.save_ovf()
+        
+        # Save 6D FieldQuantity
+        self.magnet.strain_tensor.save_ovf()
 
-    def test_read(self):
-        self.magnet.magnetization.load_ovf()
-        mag = self.magnet.magnetization.eval()
+        self.ovf_m = pyovf.read(self.name)
+        self.ovf_aex = pyovf.read(self.magnet.aex.name.replace(":", "_") + ".ovf")
+        self.ovf_strain = pyovf.read(self.magnet.strain_tensor.name.replace(":", "_") + ".ovf")
+
+    def test_1D(self):
+        self.magnet.aex = 1e-12 # Change aex
         self.magnet.aex.load_ovf()
         aex = self.magnet.aex.eval()
-        assert max_relative_error(mag, self.magnetization) < RTOL
         assert max_relative_error(aex, self.aex) < RTOL
+
+    def test_3D(self):
+        self.magnet.magnetization = (0,0,1) # Change magnetization
+        self.magnet.magnetization.load_ovf()
+        mag = self.magnet.magnetization.eval()
+        assert max_relative_error(mag, self.magnetization) < RTOL
+
+    def test_6D(self):
+        nx, ny, nz = self.magnet.grid.size
+        self.magnet.elastic_displacement = np.random.rand(3,nz,ny,nx)*1e-14 # Change strain_tensor
+        strain = np.ascontiguousarray(np.moveaxis(self.ovf_strain.data, -1, 0))
+        assert max_relative_error(strain, self.strain) < RTOL
     
     def test_read_name(self):
+        self.magnet.magnetization = (0,0,1) # Change magnetization
         self.magnet.magnetization.load_ovf(self.name)
         mag = self.magnet.magnetization.eval()
         assert max_relative_error(mag, self.magnetization) < RTOL
@@ -52,18 +69,23 @@ class TestOVF:
     def test_size(self):
         cx_ovf_m, cy_ovf_m, cz_ovf_m = self.ovf_m.xstepsize, self.ovf_m.ystepsize, self.ovf_m.zstepsize
         cx_ovf_aex, cy_ovf_aex, cz_ovf_aex = self.ovf_aex.xstepsize, self.ovf_aex.ystepsize, self.ovf_aex.zstepsize
+        cx_ovf_strain, cy_ovf_strain, cz_ovf_strain = self.ovf_strain.xstepsize, self.ovf_strain.ystepsize, self.ovf_strain.zstepsize
         cx, cy, cz = self.world.cellsize
         assert max_relative_error(cx_ovf_m, cx) < RTOL and max_relative_error(cy_ovf_m, cy) < RTOL and max_relative_error(cz_ovf_m, cz) < RTOL
         assert max_relative_error(cx_ovf_aex, cx) < RTOL and max_relative_error(cy_ovf_aex, cy) < RTOL and max_relative_error(cz_ovf_aex, cz) < RTOL
+        assert max_relative_error(cx_ovf_strain, cx) < RTOL and max_relative_error(cy_ovf_strain, cy) < RTOL and max_relative_error(cz_ovf_strain, cz) < RTOL
 
 
     def test_grid(self):
         nx_ovf_m, ny_ovf_m, nz_ovf_m = self.ovf_m.xnodes, self.ovf_m.ynodes, self.ovf_m.znodes
         nx_ovf_aex, ny_ovf_aex, nz_ovf_aex = self.ovf_aex.xnodes, self.ovf_aex.ynodes, self.ovf_aex.znodes
+        nx_ovf_strain, ny_ovf_strain, nz_ovf_strain = self.ovf_strain.xnodes, self.ovf_strain.ynodes, self.ovf_strain.znodes
         nx, ny, nz = self.magnet.grid.size
         assert nx_ovf_m == nx and ny_ovf_m == ny and nz_ovf_m == nz
         assert nx_ovf_aex == nx and ny_ovf_aex == ny and nz_ovf_aex == nz
+        assert nx_ovf_strain == nx and ny_ovf_strain == ny and nz_ovf_strain == nz
 
     def test_title(self):
         assert self.ovf_m.Title == self.magnet.magnetization.name
         assert self.ovf_aex.Title == self.magnet.aex.name
+        assert self.ovf_strain.Title == self.magnet.strain_tensor.name

--- a/test/test_ovf.py
+++ b/test/test_ovf.py
@@ -36,8 +36,8 @@ class TestOVF:
         self.magnet.strain_tensor.save_ovf()
 
         self.ovf_m = pyovf.read(self.name)
-        self.ovf_aex = pyovf.read(self.magnet.aex.name.replace(":", "_") + f"{0:06d}.ovf")
-        self.ovf_strain = pyovf.read(self.magnet.strain_tensor.name.replace(":", "_") + f"{0:06d}.ovf")
+        self.ovf_aex = pyovf.read(self.magnet.aex.name.replace(":", "_") + f"_{0:06d}.ovf")
+        self.ovf_strain = pyovf.read(self.magnet.strain_tensor.name.replace(":", "_") + f"_{0:06d}.ovf")
 
     def test_1D(self):
         self.magnet.aex = 1e-12 # Change aex

--- a/test/test_ovf.py
+++ b/test/test_ovf.py
@@ -1,7 +1,6 @@
 from mumaxplus import *
 import pyovf
 import numpy as np
-from mumaxplus.util import plot_field
 
 RTOL = 2e-7
 
@@ -26,16 +25,24 @@ class TestOVF:
         self.world.timesolver.run(0.5e-9)
 
         self.magnetization = self.magnet.magnetization.eval()
+        self.aex = self.magnet.aex.eval()
+        print()
 
         self.magnet.magnetization.save_ovf(self.name)
         self.magnet.magnetization.save_ovf()
 
-        self.ovf = pyovf.read(self.name)
+        self.magnet.aex.save_ovf()
+
+        self.ovf_m = pyovf.read(self.name)
+        self.ovf_aex = pyovf.read(self.magnet.aex.name + ".ovf")
 
     def test_read(self):
         self.magnet.magnetization.load_ovf()
         mag = self.magnet.magnetization.eval()
+        self.magnet.aex.load_ovf()
+        aex = self.magnet.aex.eval()
         assert max_relative_error(mag, self.magnetization) < RTOL
+        assert max_relative_error(aex, self.aex) < RTOL
     
     def test_read_name(self):
         self.magnet.magnetization.load_ovf(self.name)
@@ -43,14 +50,20 @@ class TestOVF:
         assert max_relative_error(mag, self.magnetization) < RTOL
 
     def test_size(self):
-        cx_ovf, cy_ovf, cz_ovf = self.ovf.xstepsize, self.ovf.ystepsize, self.ovf.zstepsize
+        cx_ovf_m, cy_ovf_m, cz_ovf_m = self.ovf_m.xstepsize, self.ovf_m.ystepsize, self.ovf_m.zstepsize
+        cx_ovf_aex, cy_ovf_aex, cz_ovf_aex = self.ovf_aex.xstepsize, self.ovf_aex.ystepsize, self.ovf_aex.zstepsize
         cx, cy, cz = self.world.cellsize
-        assert max_relative_error(cx_ovf, cx) < RTOL and max_relative_error(cy_ovf, cy) < RTOL and max_relative_error(cz_ovf, cz) < RTOL
+        assert max_relative_error(cx_ovf_m, cx) < RTOL and max_relative_error(cy_ovf_m, cy) < RTOL and max_relative_error(cz_ovf_m, cz) < RTOL
+        assert max_relative_error(cx_ovf_aex, cx) < RTOL and max_relative_error(cy_ovf_aex, cy) < RTOL and max_relative_error(cz_ovf_aex, cz) < RTOL
+
 
     def test_grid(self):
-        nx_ovf, ny_ovf, nz_ovf = self.ovf.xnodes, self.ovf.ynodes, self.ovf.znodes
+        nx_ovf_m, ny_ovf_m, nz_ovf_m = self.ovf_m.xnodes, self.ovf_m.ynodes, self.ovf_m.znodes
+        nx_ovf_aex, ny_ovf_aex, nz_ovf_aex = self.ovf_aex.xnodes, self.ovf_aex.ynodes, self.ovf_aex.znodes
         nx, ny, nz = self.magnet.grid.size
-        assert nx_ovf == nx and ny_ovf == ny and nz_ovf == nz
+        assert nx_ovf_m == nx and ny_ovf_m == ny and nz_ovf_m == nz
+        assert nx_ovf_aex == nx and ny_ovf_aex == ny and nz_ovf_aex == nz
 
     def test_title(self):
-        assert self.ovf.Title == self.magnet.magnetization.name
+        assert self.ovf_m.Title == self.magnet.magnetization.name
+        assert self.ovf_aex.Title == self.magnet.aex.name

--- a/test/test_ovf.py
+++ b/test/test_ovf.py
@@ -2,7 +2,7 @@ from mumaxplus import World, Ferromagnet, Grid
 import pyovf
 import numpy as np
 
-RTOL = 2e-7
+RTOL = 5e-7
 
 def max_relative_error(result, wanted):
     return np.max(np.abs(result - wanted) / np.abs(wanted))
@@ -18,11 +18,8 @@ class TestOVF:
         self.magnet = Ferromagnet(self.world, Grid((nx, ny, nz)))
 
         self.magnet.enable_elastodynamics = True
-        self.magnet.magnetization = (1,0,0)
         self.magnet.aex = 13e-12
         self.magnet.elastic_displacement = np.random.rand(3,nz,ny,nx)*1e-14
-
-        self.world.timesolver.run(0.5e-9)
 
         self.magnetization = self.magnet.magnetization.eval()
         self.aex = self.magnet.aex.eval()


### PR DESCRIPTION
This PR adds `save_ovf` and `load_ovf` methods to `FieldQuantities`. This allows users to save and load `FieldQuantities` via OVF files.
The `save_ovf` method uses `pyovf` and provides it with all available metadata. However, some metadata appears to be ignored (e.g. simulation time) and some fields are hard-coded in pyovf (e.g. units).
`pyovf` expects arrays with shape `(nz, ny, nx, ncomp)`, while mumax⁺ uses `(ncomp, nz, ny, nx)`. The save function reorders the axis, while the load function reverses this. To notify users of this reordering, the save function has a warning in the docstring.