### PR TITLE
add the strayfield kernel to strayfield in python

### DIFF
--- a/mumaxplus/strayfield.py
+++ b/mumaxplus/strayfield.py
@@ -99,3 +99,8 @@ class StrayField(FieldQuantity):
     @switch_radius.setter
     def switch_radius(self, value=-1):
         self._impl.switching_radius = value
+
+    @property
+    def kernel(self):
+        """Return the StrayFieldKernel."""
+        return self._impl.kernel

--- a/mumaxplus/strayfield.py
+++ b/mumaxplus/strayfield.py
@@ -102,5 +102,5 @@ class StrayField(FieldQuantity):
 
     @property
     def kernel(self):
-        """Return the StrayFieldKernel."""
+        """Return the stray_field_kernel."""
         return self._impl.kernel

--- a/src/bindings/wrap_strayfield.cpp
+++ b/src/bindings/wrap_strayfield.cpp
@@ -24,5 +24,6 @@ void wrap_strayfield(py::module& m) {
       })
       .def_property("order", &StrayField::order, &StrayField::setOrder)
       .def_property("epsilon", &StrayField::eps, &StrayField::setEps)
-      .def_property("switching_radius", &StrayField::switchingradius, &StrayField::setSwitchingradius);
+      .def_property("switching_radius", &StrayField::switchingradius, &StrayField::setSwitchingradius)
+      .def_property_readonly("kernel", [](const StrayField& sf) {return fieldToArray(sf.kernel());});
 }

--- a/src/bindings/wrap_strayfield.cpp
+++ b/src/bindings/wrap_strayfield.cpp
@@ -25,5 +25,5 @@ void wrap_strayfield(py::module& m) {
       .def_property("order", &StrayField::order, &StrayField::setOrder)
       .def_property("epsilon", &StrayField::eps, &StrayField::setEps)
       .def_property("switching_radius", &StrayField::switchingradius, &StrayField::setSwitchingradius)
-      .def_property_readonly("kernel", [](const StrayField& sf) {return fieldToArray(sf.kernel());});
+      .def_property_readonly("kernel", [](const StrayField& sf) {return fieldToArray(sf.kernel().field());});
 }

--- a/src/physics/strayfield.cpp
+++ b/src/physics/strayfield.cpp
@@ -136,3 +136,7 @@ bool StrayField::assuredZero() const {
                                 "a Ferromagnet, a (non-collinear) "
                                 "Antiferromagnet/Ferrimagnet, nor an Altermagnet.");
 }
+
+Field StrayField::kernel() const {
+    return executor_->kernel();
+}

--- a/src/physics/strayfield.cpp
+++ b/src/physics/strayfield.cpp
@@ -136,7 +136,3 @@ bool StrayField::assuredZero() const {
                                 "a Ferromagnet, a (non-collinear) "
                                 "Antiferromagnet/Ferrimagnet, nor an Altermagnet.");
 }
-
-Field StrayField::kernel() const {
-    return executor_->kernel();
-}

--- a/src/physics/strayfield.hpp
+++ b/src/physics/strayfield.hpp
@@ -65,6 +65,9 @@ class StrayFieldExecutor {
   /** Return the switching radius of the executor. */
   virtual double switchingradius() const = 0;
 
+  /** Return the strayfieldkernel as a field */
+  virtual Field kernel() const = 0;
+
  protected:
   /** Source of the stray field*/
   const Magnet* magnet_;
@@ -151,6 +154,9 @@ class StrayField : public FieldQuantity {
 
   /** Return true if one can be sure that the stray field is exactly zero. */
   bool assuredZero() const;
+
+  /** Return the strayfieldkernel as a field */
+  Field kernel() const;
 
  private:
   std::shared_ptr<const System> system_;

--- a/src/physics/strayfield.hpp
+++ b/src/physics/strayfield.hpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "fieldquantity.hpp"
+#include "strayfieldkernel.hpp"
 
 class Parameter;
 class Magnet;
@@ -66,7 +67,7 @@ class StrayFieldExecutor {
   virtual double switchingradius() const = 0;
 
   /** Return the strayfieldkernel as a field */
-  virtual Field kernel() const = 0;
+  virtual const StrayFieldKernel& kernel() const = 0;
 
  protected:
   /** Source of the stray field*/
@@ -156,7 +157,7 @@ class StrayField : public FieldQuantity {
   bool assuredZero() const;
 
   /** Return the strayfieldkernel as a field */
-  Field kernel() const;
+  const StrayFieldKernel& kernel() const { return executor_->kernel();}
 
  private:
   std::shared_ptr<const System> system_;

--- a/src/physics/strayfield.hpp
+++ b/src/physics/strayfield.hpp
@@ -66,7 +66,7 @@ class StrayFieldExecutor {
   /** Return the switching radius of the executor. */
   virtual double switchingradius() const = 0;
 
-  /** Return the strayfieldkernel as a field */
+  /** Return the StrayFieldKernel */
   virtual const StrayFieldKernel& kernel() const = 0;
 
  protected:
@@ -156,7 +156,7 @@ class StrayField : public FieldQuantity {
   /** Return true if one can be sure that the stray field is exactly zero. */
   bool assuredZero() const;
 
-  /** Return the strayfieldkernel as a field */
+  /** Return the StrayFieldKernel */
   const StrayFieldKernel& kernel() const { return executor_->kernel();}
 
  private:

--- a/src/physics/strayfieldbrute.cu
+++ b/src/physics/strayfieldbrute.cu
@@ -74,3 +74,7 @@ Field StrayFieldBruteExecutor::exec() const {
   }
   return h;
 }
+
+Field StrayFieldBruteExecutor::kernel() const {
+    return kernel_.field();
+}

--- a/src/physics/strayfieldbrute.cu
+++ b/src/physics/strayfieldbrute.cu
@@ -74,7 +74,3 @@ Field StrayFieldBruteExecutor::exec() const {
   }
   return h;
 }
-
-Field StrayFieldBruteExecutor::kernel() const {
-    return kernel_.field();
-}

--- a/src/physics/strayfieldbrute.hpp
+++ b/src/physics/strayfieldbrute.hpp
@@ -41,6 +41,8 @@ class StrayFieldBruteExecutor : public StrayFieldExecutor {
   /** Return the switching radius. */
   double switchingradius() const { return kernel_.switchingradius();}
 
+  Field kernel() const;
+
  private:
   StrayFieldKernel kernel_;
 };

--- a/src/physics/strayfieldbrute.hpp
+++ b/src/physics/strayfieldbrute.hpp
@@ -41,7 +41,7 @@ class StrayFieldBruteExecutor : public StrayFieldExecutor {
   /** Return the switching radius. */
   double switchingradius() const { return kernel_.switchingradius();}
 
-  Field kernel() const;
+  const StrayFieldKernel& kernel() const { return kernel_;};
 
  private:
   StrayFieldKernel kernel_;

--- a/src/physics/strayfieldfft.cu
+++ b/src/physics/strayfieldfft.cu
@@ -239,3 +239,7 @@ Field StrayFieldFFTExecutor::exec() const {
   cudaLaunch(h.grid().ncells(), k_unpad, h.cu(), mpad->cu());
   return h;
 }
+
+Field StrayFieldFFTExecutor::kernel() const {
+    return kernel_.field();
+}

--- a/src/physics/strayfieldfft.cu
+++ b/src/physics/strayfieldfft.cu
@@ -239,7 +239,3 @@ Field StrayFieldFFTExecutor::exec() const {
   cudaLaunch(h.grid().ncells(), k_unpad, h.cu(), mpad->cu());
   return h;
 }
-
-Field StrayFieldFFTExecutor::kernel() const {
-    return kernel_.field();
-}

--- a/src/physics/strayfieldfft.hpp
+++ b/src/physics/strayfieldfft.hpp
@@ -45,6 +45,8 @@ class StrayFieldFFTExecutor : public StrayFieldExecutor {
   /** Return the switching radius. */
   double switchingradius() const { return kernel_.switchingradius();}
 
+  Field kernel() const;
+
  private:
   StrayFieldKernel kernel_;
   int3 fftSize;

--- a/src/physics/strayfieldfft.hpp
+++ b/src/physics/strayfieldfft.hpp
@@ -45,7 +45,7 @@ class StrayFieldFFTExecutor : public StrayFieldExecutor {
   /** Return the switching radius. */
   double switchingradius() const { return kernel_.switchingradius();}
 
-  Field kernel() const;
+  const StrayFieldKernel& kernel() const { return kernel_;};
 
  private:
   StrayFieldKernel kernel_;

--- a/test/test_demag.py
+++ b/test/test_demag.py
@@ -1,5 +1,5 @@
 import numpy as np
-from mumaxplus import Ferromagnet, Grid, World, _cpp
+from mumaxplus import Ferromagnet, Grid, World
 from mumaxplus.util import MU0
 from pathlib import Path
 
@@ -11,7 +11,10 @@ def relative_error(result, wanted):
     return np.abs((wanted - result) / result)
 
 def demag_field_py(magnet):
-    kernel = _cpp._demag_kernel(magnet._impl, order, eps, R)
+    magnet.demag_field.order = order
+    magnet.demag_field.epsilon = eps
+    magnet.demag_field.switch_radius = R
+    kernel = magnet.demag_field.kernel
     mag = magnet.msat.average() * magnet.magnetization.get()
     # add padding to the magnetization so that the size of magnetization
     # matches the size of the kernel
@@ -49,12 +52,18 @@ class TestDemag:
         
         world = World((1e-9, 1e-9, 1e-9))
         magnet = Ferromagnet(world, Grid((nx, ny, nz)))
-        self.kernel = _cpp._demag_kernel(magnet._impl, order, eps, R)
+        magnet.demag_field.order = order
+        magnet.demag_field.epsilon = eps
+        magnet.demag_field.switch_radius = R
+        self.kernel = magnet.demag_field.kernel
 
         # in the aspect tests, the cellsizes are different
         world = World((1e-9, 1.27e-9, 1.13e-9))
         magnet = Ferromagnet(world, Grid((nx_aspect, ny_aspect, nz_aspect)))
-        self.kernel_aspect = _cpp._demag_kernel(magnet._impl, order, eps, R)
+        magnet.demag_field.order = order
+        magnet.demag_field.epsilon = eps
+        magnet.demag_field.switch_radius = R
+        self.kernel_aspect = magnet.demag_field.kernel
 
         # open all files
         script_dir = Path(__file__).resolve().parent
@@ -81,7 +90,10 @@ class TestDemag:
         nx, ny, nz = 126, 64, 8
         world = World((1e-9, 1e-9, 1e-9))
         magnet = Ferromagnet(world, Grid((nx, ny, nz)))
-        mumaxplus_result = _cpp._demag_kernel(magnet._impl, 11, 5e-10, 5e-9)[0,nz:,ny:, nx:] # Nxx component
+        magnet.demag_field.order = 11
+        magnet.demag_field.epsilon = 5e-10
+        magnet.demag_field.switch_radius = 5e-9
+        mumaxplus_result = magnet.demag_field.kernel[0,nz:,ny:,nx:]
 
         # avoid fake errors when both values are super small
         mask = ~((np.abs(self.exact_Nxx) < 5e-15) & (np.abs(mumaxplus_result) < 5e-15))
@@ -138,3 +150,8 @@ class TestDemag:
 
         err = np.max(relative_error(mumaxplus_result, self.exact_aspect_Nxy))
         assert err < 1e-5
+
+
+world = World((1e-9, 1e-9, 1e-9))
+magnet = Ferromagnet(world, Grid((nx, ny, nz)))
+print(magnet.demag_field.kernel)

--- a/test/test_demag.py
+++ b/test/test_demag.py
@@ -150,8 +150,3 @@ class TestDemag:
 
         err = np.max(relative_error(mumaxplus_result, self.exact_aspect_Nxy))
         assert err < 1e-5
-
-
-world = World((1e-9, 1e-9, 1e-9))
-magnet = Ferromagnet(world, Grid((nx, ny, nz)))
-print(magnet.demag_field.kernel)

--- a/test/test_demag.py
+++ b/test/test_demag.py
@@ -1,5 +1,5 @@
 import numpy as np
-from mumaxplus import Ferromagnet, Grid, World
+from mumaxplus import Ferromagnet, Grid, World, _cpp
 from mumaxplus.util import MU0
 from pathlib import Path
 
@@ -11,10 +11,7 @@ def relative_error(result, wanted):
     return np.abs((wanted - result) / result)
 
 def demag_field_py(magnet):
-    magnet.demag_field.order = order
-    magnet.demag_field.epsilon = eps
-    magnet.demag_field.switch_radius = R
-    kernel = magnet.demag_field.kernel
+    kernel = _cpp._demag_kernel(magnet._impl, order, eps, R)
     mag = magnet.msat.average() * magnet.magnetization.get()
     # add padding to the magnetization so that the size of magnetization
     # matches the size of the kernel
@@ -52,18 +49,12 @@ class TestDemag:
         
         world = World((1e-9, 1e-9, 1e-9))
         magnet = Ferromagnet(world, Grid((nx, ny, nz)))
-        magnet.demag_field.order = order
-        magnet.demag_field.epsilon = eps
-        magnet.demag_field.switch_radius = R
-        self.kernel = magnet.demag_field.kernel
+        self.kernel = _cpp._demag_kernel(magnet._impl, order, eps, R)
 
         # in the aspect tests, the cellsizes are different
         world = World((1e-9, 1.27e-9, 1.13e-9))
         magnet = Ferromagnet(world, Grid((nx_aspect, ny_aspect, nz_aspect)))
-        magnet.demag_field.order = order
-        magnet.demag_field.epsilon = eps
-        magnet.demag_field.switch_radius = R
-        self.kernel_aspect = magnet.demag_field.kernel
+        self.kernel_aspect = _cpp._demag_kernel(magnet._impl, order, eps, R)
 
         # open all files
         script_dir = Path(__file__).resolve().parent
@@ -90,10 +81,7 @@ class TestDemag:
         nx, ny, nz = 126, 64, 8
         world = World((1e-9, 1e-9, 1e-9))
         magnet = Ferromagnet(world, Grid((nx, ny, nz)))
-        magnet.demag_field.order = 11
-        magnet.demag_field.epsilon = 5e-10
-        magnet.demag_field.switch_radius = 5e-9
-        mumaxplus_result = magnet.demag_field.kernel[0,nz:,ny:,nx:]
+        mumaxplus_result = _cpp._demag_kernel(magnet._impl, 11, 5e-10, 5e-9)[0,nz:,ny:, nx:] # Nxx 
 
         # avoid fake errors when both values are super small
         mask = ~((np.abs(self.exact_Nxx) < 5e-15) & (np.abs(mumaxplus_result) < 5e-15))


### PR DESCRIPTION
This PR will allow the user to access the `Field` generated by `StrayFieldKernel`. This means that we don't have to use this anymore:
```python
from _mumaxpluscpp import _demag_kernel

_demag_kernel(magnet._impl)
```
test_demag.py has also been changed such that it uses this new feature.