### PR TITLE
Add chiral magnetoelastic field and force with tests

### DIFF
--- a/mumaxplus/ferromagnet.py
+++ b/mumaxplus/ferromagnet.py
@@ -653,7 +653,7 @@ class Ferromagnet(Magnet):
         
         See Also
         --------
-        B2
+        B2, B_chiral
         """
         return Parameter(self._impl.B1)
 
@@ -678,7 +678,7 @@ class Ferromagnet(Magnet):
         
         See Also
         --------
-        B1
+        B1, B_chiral
         """
         return Parameter(self._impl.B2)
 
@@ -696,6 +696,28 @@ class Ferromagnet(Magnet):
             warnings.warn("The second magnetoelastic coupling constant B2"
                           + " is set to a positive value, instead of negative (or zero)."
                           + " Make sure this is intentional!", UserWarning)
+
+    @property
+    def B_chiral(self) -> Parameter:
+        r"""Chiral magnetoelastic coupling constant (J/m³).
+
+        Notes
+        -----
+        Materials of the cubic point group 23 (or B20 compounds) can have an additional chiral magnetoelastic coupling, with the following energy density [1]_.
+
+        .. math:: \mathcal{E} = B_\text{chiral} \sum_{i, j, k} \epsilon_{ijk} \varepsilon_{ii} m_j^2
+
+        .. [1] L\ . Franke, “Elastic Coupling at Quantum Phase Transitions and in Chiral Magnets,” Das Karlsruher Institut für Technologie, Karlsruhe, 2025. doi: 10.5445/IR/1000184834.
+        
+        See Also
+        --------
+        B1, B2
+        """
+        return Parameter(self._impl.B_chiral)
+
+    @B_chiral.setter
+    def B_chiral(self, value):
+        self.B_chiral.set(value)
 
     # ----- POISSON SYSTEM ----------------------
 
@@ -1128,7 +1150,7 @@ class Ferromagnet(Magnet):
 
         See Also
         --------
-        B1, B2
+        B1, B2, B_chiral
         Magnet.strain_tensor, Magnet.rigid_norm_strain, Magnet.rigid_shear_strain
         magnetoelastic_force
         """
@@ -1160,7 +1182,7 @@ class Ferromagnet(Magnet):
 
         See Also
         --------
-        B1, B2
+        B1, B2, B_chiral
         Magnet.effective_body_force, magnetoelastic_field
         """
         return FieldQuantity(_cpp.magnetoelastic_force(self._impl))

--- a/mumaxplus/ferromagnet.py
+++ b/mumaxplus/ferromagnet.py
@@ -703,7 +703,7 @@ class Ferromagnet(Magnet):
 
         Notes
         -----
-        Materials of the cubic point group 23 (or B20 compounds) can have an additional chiral magnetoelastic coupling, with the following energy density [1]_.
+        Materials of the cubic point group 23 (or B20 compounds) can have a chiral magnetoelastic coupling, with the following energy density [1]_.
 
         .. math:: \mathcal{E} = B_\text{chiral} \sum_{i, j, k} \epsilon_{ijk} \varepsilon_{ii} m_j^2
 

--- a/mumaxplus/ferromagnet.py
+++ b/mumaxplus/ferromagnet.py
@@ -708,7 +708,9 @@ class Ferromagnet(Magnet):
 
         .. math:: \mathcal{E} = B_\text{chiral} \sum_{i, j, k} \epsilon_{ijk} \varepsilon_{ii} m_j^2
 
-        This comes from equations (8.12) and (8.16) in Ref. [1], where
+        Here :math:`\epsilon_{ijk}` is the Levi-Civita symbol and
+        :math:`\varepsilon_{ii}` denotes the normal strain components.
+        This energy density comes from equations (8.12) and (8.16) in Ref. [1], where
         B_chiral corresponds to :math:`\lambda_{12}`. Magnetoelastic coupling constants
         B1 and B2 correspond to :math:`\lambda_{11}` and :math:`2 \lambda_{44}` respectively.
         These lambdas are not the usual magnetostrictive coefficients.

--- a/mumaxplus/ferromagnet.py
+++ b/mumaxplus/ferromagnet.py
@@ -703,9 +703,15 @@ class Ferromagnet(Magnet):
 
         Notes
         -----
-        Materials of the cubic point group 23 (or B20 compounds) can have a chiral magnetoelastic coupling, with the following energy density [1]_.
+        Materials of the cubic point group 23 (or B20 compounds) can have a
+        chiral magnetoelastic coupling, with the following energy density.
 
         .. math:: \mathcal{E} = B_\text{chiral} \sum_{i, j, k} \epsilon_{ijk} \varepsilon_{ii} m_j^2
+
+        This comes from equations (8.12) and (8.16) in Ref. [1], where
+        B_chiral corresponds to :math:`\lambda_{12}`. Magnetoelastic coupling constants
+        B1 and B2 correspond to :math:`\lambda_{11}` and :math:`2 \lambda_{44}` respectively.
+        These lambdas are not the usual magnetostrictive coefficients.
 
         .. [1] L\ . Franke, “Elastic Coupling at Quantum Phase Transitions and in Chiral Magnets,” Das Karlsruher Institut für Technologie, Karlsruhe, 2025. doi: 10.5445/IR/1000184834.
         

--- a/src/bindings/wrap_ferromagnet.cpp
+++ b/src/bindings/wrap_ferromagnet.cpp
@@ -72,6 +72,7 @@ void wrap_ferromagnet(py::module& m) {
       .def_readonly("poisson_system", &Ferromagnet::poissonSystem)
       .def_readonly("B1", &Ferromagnet::B1)
       .def_readonly("B2", &Ferromagnet::B2)
+      .def_readonly("B_chiral", &Ferromagnet::BChiral)
       
       .def("reset_noise_generator", &Ferromagnet::resetNoiseGenerator)
       .def("minimize", &Ferromagnet::minimize, py::arg("tol"), py::arg("nsamples"))

--- a/src/physics/ferromagnet.cpp
+++ b/src/physics/ferromagnet.cpp
@@ -59,7 +59,8 @@ Ferromagnet::Ferromagnet(std::shared_ptr<System> system_ptr,
       poissonSystem(this), 
       // magnetoelasticity
       B1(system(), 0.0, name + ":B1", "J/m3"),
-      B2(system(), 0.0, name + ":B1", "J/m3") {
+      B2(system(), 0.0, name + ":B2", "J/m3"),
+      BChiral(system(), 0.0, name + ":BChiral", "J/m3") {
     {// Initialize random magnetization
     // TODO: this can be done much more efficient somewhere else
     int nvalues = 3 * this->grid().ncells();

--- a/src/physics/ferromagnet.hpp
+++ b/src/physics/ferromagnet.hpp
@@ -103,4 +103,5 @@ class Ferromagnet : public Magnet {
   // Magnetoelasticity
   Parameter B1;  // First magnetoelastic coupling constant
   Parameter B2;  // Second magnetoelastic coupling constant
+  Parameter BChiral;  // Chiral magnetoelastic coupling constant
 };

--- a/src/physics/magnetoelasticfield.cu
+++ b/src/physics/magnetoelasticfield.cu
@@ -23,7 +23,8 @@ bool dynamicMagnetoelasticAssuredZero(const Ferromagnet* magnet) {
   }
 
   return (!enableElastodynamics || magnet->msat.assuredZero() ||
-          (magnet->B1.assuredZero() && magnet->B2.assuredZero()));
+          (magnet->B1.assuredZero() && magnet->B2.assuredZero() &&
+           magnet->BChiral.assuredZero()));
 }
 
 bool rigidMagnetoelasticAssuredZero(const Ferromagnet* magnet) {
@@ -38,7 +39,8 @@ bool rigidMagnetoelasticAssuredZero(const Ferromagnet* magnet) {
   }
 
   return (!appliedStrain || magnet->msat.assuredZero() ||
-          (magnet->B1.assuredZero() && magnet->B2.assuredZero()));
+          (magnet->B1.assuredZero() && magnet->B2.assuredZero() &&
+           magnet->BChiral.assuredZero()));
 }
 
 __global__ void k_dynamicMagnetoelasticField(CuField hField,
@@ -46,6 +48,7 @@ __global__ void k_dynamicMagnetoelasticField(CuField hField,
                                              const CuField strain,
                                              const CuParameter B1,
                                              const CuParameter B2,
+                                             const CuParameter BChiral,
                                              const CuParameter msat) {
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
   const CuSystem system = hField.system;
@@ -66,7 +69,9 @@ __global__ void k_dynamicMagnetoelasticField(CuField hField,
     if (ip2 >= 3) ip2 -= 3;
 
     hField.setValueInCell(idx, i, - 2 / msat.valueAt(idx) *
-      (B1.valueAt(idx) *  strain.valueAt(idx, i)       * mField.valueAt(idx, i)   + 
+      ((B1.valueAt(idx) * strain.valueAt(idx, i) +
+        BChiral.valueAt(idx) * (- strain.valueAt(idx, ip1) + strain.valueAt(idx, ip2))
+       ) * mField.valueAt(idx, i) + 
        B2.valueAt(idx) * (strain.valueAt(idx, i+ip1+2) * mField.valueAt(idx, ip1) + 
                           strain.valueAt(idx, i+ip2+2) * mField.valueAt(idx, ip2))));
   }
@@ -78,6 +83,7 @@ __global__ void k_rigidMagnetoelasticField(CuField hField,
                                            const CuVectorParameter shearStrain,
                                            const CuParameter B1,
                                            const CuParameter B2,
+                                           const CuParameter BChiral,
                                            const CuParameter msat) {
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
   const CuSystem system = hField.system;
@@ -98,7 +104,9 @@ __global__ void k_rigidMagnetoelasticField(CuField hField,
     if (ip2 >= 3) ip2 -= 3;
 
     hField.setValueInCell(idx, i, - 2 / msat.valueAt(idx) *
-    (B1.valueAt(idx) *  normStrain.valueAt(idx, i)        * mField.valueAt(idx, i)   + 
+    ((B1.valueAt(idx) * normStrain.valueAt(idx, i) +
+      BChiral.valueAt(idx) * (- normStrain.valueAt(idx, ip1) + normStrain.valueAt(idx, ip2))
+     ) * mField.valueAt(idx, i) + 
      B2.valueAt(idx) * (shearStrain.valueAt(idx, i+ip1-1) * mField.valueAt(idx, ip1) + 
                         shearStrain.valueAt(idx, i+ip2-1) * mField.valueAt(idx, ip2))));
   }
@@ -115,6 +123,7 @@ Field evalMagnetoelasticField(const Ferromagnet* magnet) {
   CuField mField = magnet->magnetization()->field().cu();
   CuParameter B1 = magnet->B1.cu();
   CuParameter B2 = magnet->B2.cu();
+  CuParameter BChiral = magnet->BChiral.cu();
   CuParameter msat = magnet->msat.cu();
 
   if (!rigidMagnetoelasticAssuredZero(magnet)) {  // maybe use rigid strain
@@ -123,13 +132,13 @@ Field evalMagnetoelasticField(const Ferromagnet* magnet) {
       CuVectorParameter shearStrain = magnet->hostMagnet()->rigidShearStrain.cu();
 
       cudaLaunch(ncells, k_rigidMagnetoelasticField, hField.cu(), mField,
-                normStrain, shearStrain, B1, B2, msat);
+                normStrain, shearStrain, B1, B2, BChiral, msat);
     } else {  // independent magnet
       CuVectorParameter normStrain = magnet->rigidNormStrain.cu();
       CuVectorParameter shearStrain = magnet->rigidShearStrain.cu();
 
       cudaLaunch(ncells, k_rigidMagnetoelasticField, hField.cu(), mField,
-                normStrain, shearStrain, B1, B2, msat);
+                normStrain, shearStrain, B1, B2, BChiral, msat);
     }
 
     return hField;
@@ -144,7 +153,7 @@ Field evalMagnetoelasticField(const Ferromagnet* magnet) {
   }
 
   cudaLaunch(ncells, k_dynamicMagnetoelasticField, hField.cu(), mField,
-            strain.cu(), B1, B2, msat);
+            strain.cu(), B1, B2, BChiral, msat);
   return hField;
 }
 

--- a/src/physics/magnetoelasticforce.cu
+++ b/src/physics/magnetoelasticforce.cu
@@ -11,6 +11,7 @@ __global__ void k_magnetoelasticForce(CuField fField,
                                       const CuField m,
                                       const CuParameter B1,
                                       const CuParameter B2,
+                                      const CuParameter BChiral,
                                       const real3 w,  // w = 1/cellsize
                                       const Grid mastergrid) {
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -89,6 +90,7 @@ __global__ void k_magnetoelasticForce(CuField fField,
     real f_i = 2 * B1.valueAt(idx) * m_here[i] * der[i][i];
     f_i += B2.valueAt(idx) * m_here[i] * (der[ip1][ip1] + der[ip2][ip2]);
     f_i += B2.valueAt(idx) * (m_here[ip1] * der[ip1][i] + m_here[ip2] * der[ip2][i]);
+    f_i += BChiral.valueAt(idx) * (m_here[ip1] * der[i][ip1] - m_here[ip2] * der[i][ip2]);
     fField.setValueInCell(idx, i, f_i);
   }
 }
@@ -104,9 +106,10 @@ Field evalMagnetoelasticForce(const Ferromagnet* magnet) {
   CuField m = magnet->magnetization()->field().cu();
   CuParameter B1 = magnet->B1.cu();
   CuParameter B2 = magnet->B2.cu();
+  CuParameter BChiral = magnet->BChiral.cu();
   real3 w = 1 / magnet->cellsize();
   Grid mastergrid = magnet->world()->mastergrid();
-  cudaLaunch(ncells, k_magnetoelasticForce, fField.cu(), m, B1, B2, w, mastergrid);
+  cudaLaunch(ncells, k_magnetoelasticForce, fField.cu(), m, B1, B2, BChiral, w, mastergrid);
   return fField;
 }
 

--- a/test/test_magnetoelasticfield.py
+++ b/test/test_magnetoelasticfield.py
@@ -45,14 +45,16 @@ def create_magnet(d_comp, m_comp):
     return magnet
 
 
-def sine_displacement(magnet, i_comp, j_comp, B1, B2):
-    """Creates the displacement following a sine in the d_comp direction
-    and cosine in another direction it then calculates the magnetoelasticforce.
+def sine_displacement(magnet, i_comp, j_comp, B1=0, B2=0, Bc=0):
+    """Creates a displacement in the j_comp direction following a sine along the
+    i_comp direction. Then calculates and compares analytical and numerical
+    magnetoelastic field.
     """
     magnet.enable_elastodynamics = True  # just in case
 
     magnet.B1 = B1
     magnet.B2 = B2
+    magnet.B_chiral = Bc
 
     L = N*cellsize[i_comp]
     k = P*2*math.pi/L
@@ -90,64 +92,93 @@ def sine_displacement(magnet, i_comp, j_comp, B1, B2):
 
         B_anal[i,...] = - 2  / msat * (
             B1 *  strain_anal[i,...] * m[i,...] + 
+            Bc * (-strain_anal[ip1,...] + strain_anal[ip2,...]) * m[i,...] +
             B2 * (strain_anal[i+ip1+2,...] * m[ip1,...] + 
                   strain_anal[i+ip2+2,...] * m[ip2,...]))
 
     assert max_semirelative_error(B_num, B_anal) < RTOL
 
-def test_x_Exx_B1():
+# --- B1 ---
+
+def test_mx_Exx_B1():
     m_comp, i, j = 0, 0, 0
-    B1, B2 = B, 0
     magnet = create_magnet(i, m_comp)
-    sine_displacement(magnet, i, j, B1, B2)
+    sine_displacement(magnet, i, j, B1=B)
 
-def test_y_Eyy_B1():
+def test_my_Eyy_B1():
     m_comp, i, j = 1, 1, 1
-    B1, B2 = B, 0
     magnet = create_magnet(i, m_comp)
-    sine_displacement(magnet, i, j, B1, B2)
+    sine_displacement(magnet, i, j, B1=B)
 
-def test_z_Ezz_B1():
+def test_mz_Ezz_B1():
     m_comp, i, j = 2, 2, 2
-    B1, B2 = B, 0
     magnet = create_magnet(i, m_comp)
-    sine_displacement(magnet, i, j, B1, B2)
+    sine_displacement(magnet, i, j, B1=B)
 
-def test_y_Exy_B2():
+# --- B2 ---
+
+def test_my_Exy_B2():
     m_comp, i, j = 1, 0, 1
-    B1, B2 = 0, B
     magnet = create_magnet(i, m_comp)
-    sine_displacement(magnet, i, j, B1, B2)
+    sine_displacement(magnet, i, j, B2=B)
 
-def test_z_Exz_B2():
+def test_mz_Exz_B2():
     m_comp, i, j = 2, 0, 2
-    B1, B2 = 0, B
     magnet = create_magnet(i, m_comp)
-    sine_displacement(magnet, i, j, B1, B2)
+    sine_displacement(magnet, i, j, B2=B)
 
-def test_x_Exy_B2():
+def test_mx_Exy_B2():
     m_comp, i, j = 0, 0, 1
-    B1, B2 = 0, B
     magnet = create_magnet(i, m_comp)
-    sine_displacement(magnet, i, j, B1, B2)
+    sine_displacement(magnet, i, j, B2=B)
 
-def test_z_Eyz_B2():
+def test_mz_Eyz_B2():
     m_comp, i, j = 2, 1, 2
-    B1, B2 = 0, B
     magnet = create_magnet(i, m_comp)
-    sine_displacement(magnet, i, j, B1, B2)
+    sine_displacement(magnet, i, j, B2=B)
 
-def test_x_Exz_B2():
+def test_mx_Exz_B2():
     m_comp, i, j = 0, 0, 2
-    B1, B2 = 0, B
     magnet = create_magnet(i, m_comp)
-    sine_displacement(magnet, i, j, B1, B2)
+    sine_displacement(magnet, i, j, B2=B)
 
-def test_y_Eyz_B2():
+def test_my_Eyz_B2():
     m_comp, i, j = 1, 1, 2
-    B1, B2 = 0, B
     magnet = create_magnet(i, m_comp)
-    sine_displacement(magnet, i, j, B1, B2)
+    sine_displacement(magnet, i, j, B2=B)
+
+# --- Bc ---
+
+def test_mx_Eyy_Bc():
+    m_comp, i, j = 0, 1, 1
+    magnet = create_magnet(i, m_comp)
+    sine_displacement(magnet, i, j, Bc=B)
+
+def test_mx_Ezz_Bc():
+    m_comp, i, j = 0, 2, 2
+    magnet = create_magnet(i, m_comp)
+    sine_displacement(magnet, i, j, Bc=B)
+
+def test_my_Exx_Bc():
+    m_comp, i, j = 1, 0, 0
+    magnet = create_magnet(i, m_comp)
+    sine_displacement(magnet, i, j, Bc=B)
+
+def test_my_Ezz_Bc():
+    m_comp, i, j = 1, 2, 2
+    magnet = create_magnet(i, m_comp)
+    sine_displacement(magnet, i, j, Bc=B)
+
+def test_mz_Exx_Bc():
+    m_comp, i, j = 2, 0, 0
+    magnet = create_magnet(i, m_comp)
+    sine_displacement(magnet, i, j, Bc=B)
+
+def test_mz_Eyy_Bc():
+    m_comp, i, j = 2, 1, 1
+    magnet = create_magnet(i, m_comp)
+    sine_displacement(magnet, i, j, Bc=B)
+
 
 def test_random():
     """Test with a random magnetization and displacement.
@@ -163,9 +194,10 @@ def test_random():
     magnet.enable_elastodynamics = True
 
     magnet.msat = msat
-    B1, B2 = B, 0.5*B
+    B1, B2, Bc = B, 0.5*B, 0.3*B
     magnet.B1 = B1
     magnet.B2 = B2
+    magnet.B_chiral = Bc
 
     L = N*cellsize[0]
     k = P*2*math.pi/L
@@ -186,6 +218,7 @@ def test_random():
 
         B_anal[i,...] = - 2  / msat * (
             B1 *  strain[i,...] * m[i,...] + 
+            Bc * (-strain[ip1,...] + strain[ip2,...]) * m[i,...] +
             B2 * (strain[i+ip1+2,...] * m[ip1,...] + 
                   strain[i+ip2+2,...] * m[ip2,...]))
 

--- a/test/test_magnetoelasticfield.py
+++ b/test/test_magnetoelasticfield.py
@@ -50,8 +50,6 @@ def sine_displacement(magnet, i_comp, j_comp, B1=0, B2=0, Bc=0):
     i_comp direction. Then calculates and compares analytical and numerical
     magnetoelastic field.
     """
-    magnet.enable_elastodynamics = True  # just in case
-
     magnet.B1 = B1
     magnet.B2 = B2
     magnet.B_chiral = Bc

--- a/test/test_magnetoelasticfield.py
+++ b/test/test_magnetoelasticfield.py
@@ -197,9 +197,6 @@ def test_random():
     magnet.B2 = B2
     magnet.B_chiral = Bc
 
-    L = N*cellsize[0]
-    k = P*2*math.pi/L
-
     def displacement_func(x, y, z):
         return tuple(np.random.rand(3))
 
@@ -220,4 +217,40 @@ def test_random():
             B2 * (strain[i+ip1+2,...] * m[ip1,...] + 
                   strain[i+ip2+2,...] * m[ip2,...]))
 
-    assert max_semirelative_error(B_num, B_anal) < RTOL
+    assert max_semirelative_error(B_num, B_anal) < 1e-6
+
+
+def test_rigid_magnetoelastic_field():
+    """Test with a random magnetization and rigid norm and shear strain.
+    """
+    nx, ny, nz = N, 4, 2  # any shape would do
+
+    world = World(cellsize)
+    magnet =  Ferromagnet(world, Grid((nx, ny, nz)))
+
+    magnet.msat = msat
+    B1, B2, Bc = B, 0.5*B, 0.3*B
+    magnet.B1 = B1
+    magnet.B2 = B2
+    magnet.B_chiral = Bc
+
+    norm_strain = np.random.rand(3, nz, ny, nx)
+    shear_strain = np.random.rand(3, nz, ny, nx)
+    magnet.rigid_norm_strain = norm_strain
+    magnet.rigid_shear_strain = shear_strain
+    
+    B_num = magnet.magnetoelastic_field.eval()
+    B_anal = np.zeros(shape=B_num.shape)
+
+    m = magnet.magnetization.eval()
+    for i in range(3):
+        ip1 = (i+1)%3
+        ip2 = (i+2)%3
+
+        B_anal[i,...] = - 2  / msat * (
+            B1 *  norm_strain[i,...] * m[i,...] + 
+            Bc * (-norm_strain[ip1,...] + norm_strain[ip2,...]) * m[i,...] +
+            B2 * (shear_strain[i+ip1-1,...] * m[ip1,...] + 
+                  shear_strain[i+ip2-1,...] * m[ip2,...]))
+
+    assert max_semirelative_error(B_num, B_anal) < 1e-6

--- a/test/test_magnetoelasticforce.py
+++ b/test/test_magnetoelasticforce.py
@@ -22,7 +22,7 @@ def max_semirelative_error(result, wanted):
     return max_absolute_error(result, wanted) / np.max(abs(wanted))
 
 
-def create_magnet(d_comp, B1, B2):
+def create_magnet(d_comp):
     """Makes a world with a 1D magnet in the d_comp direction.
     """
     gridsize, gridsize_magnet, pbc_repetitions = [0, 0, 0], [1, 1, 1], [0, 0, 0]
@@ -34,17 +34,16 @@ def create_magnet(d_comp, B1, B2):
     magnet =  Ferromagnet(world, Grid(gridsize_magnet))
     magnet.enable_elastodynamics = True
 
-    magnet.B1 = B1
-    magnet.B2 = B2
-
-    return world, magnet
+    return magnet
 
 
-def sine_force(magnet, d_comp, comp_cos, B1, B2):
+def sine_force(magnet, d_comp, comp_cos, B1=0, B2=0, Bc=0):
     """Creates the magnetization following a sine in the d_comp direction
     and cosine in another direction it then calculates the magnetoelasticforce.
     """
-    magnet.enable_elastodynamics = True  # just in case
+    magnet.B1 = B1
+    magnet.B2 = B2
+    magnet.B_chiral = Bc
 
     L = N*cellsize[d_comp]
     k = P*2*math.pi/L
@@ -57,66 +56,95 @@ def sine_force(magnet, d_comp, comp_cos, B1, B2):
         return tuple(m)
 
     magnet.magnetization = magnetization_func
+    mag = magnet.magnetization.eval()
 
     force_num = magnet.magnetoelastic_force.eval()
     
     force_anal = np.zeros(shape=force_num.shape)
-    force_anal[d_comp,...] = 2 * B1 * k * magnet.magnetization.eval()[d_comp,...] * magnet.magnetization.eval()[comp_cos,...]
-    force_anal[comp_cos,...] = B2 * k * (magnet.magnetization.eval()[comp_cos,...]**2 - magnet.magnetization.eval()[d_comp,...]**2)
+    chiral_sign = -1 if comp_cos == (d_comp + 1)%3 else 1
+    force_anal[d_comp,...] = 2 * B1 * k * mag[d_comp,...] * mag[comp_cos,...] + \
+                    chiral_sign * Bc * k * mag[comp_cos,...] * mag[d_comp,...]
+    force_anal[comp_cos,...] = B2 * k * (mag[comp_cos,...]**2 - mag[d_comp,...]**2)
     
     assert max_semirelative_error(force_num, force_anal) < RTOL
 
+# --- B1 ---
 
 def test_sinx_cosx_0_B1():
     d_comp = 0
-    B1, B2 = B, 0
-    world, magnet = create_magnet(d_comp, B1, B2)
-    sine_force(magnet, d_comp, (d_comp+1)%3, B1, B2)
+    magnet = create_magnet(d_comp)
+    sine_force(magnet, d_comp, (d_comp+1)%3, B1=B)
 
 def test_0_siny_cosy_B1():
     d_comp = 1
-    B1, B2 = B, 0
-    world, magnet = create_magnet(d_comp, B1, B2)
-    sine_force(magnet, d_comp, (d_comp+1)%3, B1, B2)
+    magnet = create_magnet(d_comp)
+    sine_force(magnet, d_comp, (d_comp+1)%3, B1=B)
 
 def test_cosz_0_sinz_B1():
     d_comp = 2
-    B1, B2 = B, 0
-    world, magnet = create_magnet(d_comp, B1, B2)
-    sine_force(magnet, d_comp, (d_comp+1)%3, B1, B2)
+    magnet = create_magnet(d_comp)
+    sine_force(magnet, d_comp, (d_comp+1)%3, B1=B)
+
+# --- B2 ---
 
 def test_sinx_cosx_0_B2():
     d_comp = 0
-    B1, B2 = 0, B
-    world, magnet = create_magnet(d_comp, B1, B2)
-    sine_force(magnet, d_comp, (d_comp+1)%3, B1, B2)
+    magnet = create_magnet(d_comp)
+    sine_force(magnet, d_comp, (d_comp+1)%3, B2=B)
 
 def test_0_siny_cosy_B2():
     d_comp = 1
-    B1, B2 = 0, B
-    world, magnet = create_magnet(d_comp, B1, B2)
-    sine_force(magnet, d_comp, (d_comp+1)%3, B1, B2)
+    magnet = create_magnet(d_comp)
+    sine_force(magnet, d_comp, (d_comp+1)%3, B2=B)
 
 def test_cosz_0_sinz_B2():
     d_comp = 2
-    B1, B2 = 0, B
-    world, magnet = create_magnet(d_comp, B1, B2)
-    sine_force(magnet, d_comp, (d_comp+1)%3, B1, B2)
+    magnet = create_magnet(d_comp)
+    sine_force(magnet, d_comp, (d_comp+1)%3, B2=B)
 
 def test_sinx_0_cosx_B2():
     d_comp = 0
-    B1, B2 = 0, B
-    world, magnet = create_magnet(d_comp, B1, B2)
-    sine_force(magnet, d_comp, (d_comp+2)%3, B1, B2)
+    magnet = create_magnet(d_comp)
+    sine_force(magnet, d_comp, (d_comp+2)%3, B2=B)
 
 def test_cosy_siny_0_B2():
     d_comp = 1
-    B1, B2 = 0, B
-    world, magnet = create_magnet(d_comp, B1, B2)
-    sine_force(magnet, d_comp, (d_comp+2)%3, B1, B2)
+    magnet = create_magnet(d_comp)
+    sine_force(magnet, d_comp, (d_comp+2)%3, B2=B)
 
 def test_0_cosz_sinz_B2():
     d_comp = 2
-    B1, B2 = 0, B
-    world, magnet = create_magnet(d_comp, B1, B2)
-    sine_force(magnet, d_comp, (d_comp+2)%3, B1, B2)
+    magnet = create_magnet(d_comp)
+    sine_force(magnet, d_comp, (d_comp+2)%3, B2=B)
+
+# --- Bc ---
+
+def test_sinx_cosx_0_Bc():
+    d_comp = 0
+    magnet = create_magnet(d_comp)
+    sine_force(magnet, d_comp, (d_comp+1)%3, Bc=B)
+
+def test_0_siny_cosy_Bc():
+    d_comp = 1
+    magnet = create_magnet(d_comp)
+    sine_force(magnet, d_comp, (d_comp+1)%3, Bc=B)
+
+def test_cosz_0_sinz_Bc():
+    d_comp = 2
+    magnet = create_magnet(d_comp)
+    sine_force(magnet, d_comp, (d_comp+1)%3, Bc=B)
+
+def test_sinx_0_cosx_Bc():
+    d_comp = 0
+    magnet = create_magnet(d_comp)
+    sine_force(magnet, d_comp, (d_comp+2)%3, Bc=B)
+
+def test_cosy_siny_0_Bc():
+    d_comp = 1
+    magnet = create_magnet(d_comp)
+    sine_force(magnet, d_comp, (d_comp+2)%3, Bc=B)
+
+def test_0_cosz_sinz_Bc():
+    d_comp = 2
+    magnet = create_magnet(d_comp)
+    sine_force(magnet, d_comp, (d_comp+2)%3, Bc=B)


### PR DESCRIPTION
Materials of the cubic point group 23 (or B20 compounds) can have an additional chiral magnetoelastic coupling, with the following energy density (https://doi.org/10.5445/IR/1000184834).
$\mathcal{E} = B_c \sum_{i, j, k} \epsilon_{ijk} \varepsilon_{ii} m_j^2$
This pull request adds the effective field and force density resulting from this energy density, including unit tests.