### PR TITLE
Make overlap more flexible

### DIFF
--- a/src/core/reduce.cu
+++ b/src/core/reduce.cu
@@ -290,3 +290,55 @@ bool isUniformField(const Field& f) {
   }
   return true;
 }
+
+__global__ void k_geometriesOverlap(bool* result,
+                                     Grid grid1, bool const* geometry1,
+                                     Grid grid2, bool const* geometry2,
+                                     int3 lo, int3 n, int ncells) {
+  __shared__ bool sdata[BLOCKDIM];
+  int tid = threadIdx.x;
+
+  bool found = false;
+  for (int i = tid; i < ncells; i += BLOCKDIM) {
+    // unravel flat index i into a 3D offset within [0, n)
+    int x = i % n.x;
+    int y = (i / n.x) % n.y;
+    int z = i / (n.x * n.y);
+    int3 coo{lo.x + x, lo.y + y, lo.z + z};
+
+    bool in1 = !geometry1 || geometry1[grid1.coord2index(coo)];
+    bool in2 = !geometry2 || geometry2[grid2.coord2index(coo)];
+    if (in1 && in2) {
+      found = true;
+      break;  // Once one overlap is found we can stop
+    }
+  }
+
+  sdata[tid] = found;
+  __syncthreads();
+
+  // Reduce the block
+  for (unsigned int s = BLOCKDIM / 2; s > 0; s >>= 1) {
+    if (tid < s)
+      sdata[tid] = sdata[tid] || sdata[tid + s];
+    __syncthreads();
+  }
+
+  if (tid == 0)
+    *result = sdata[0];
+}
+
+bool geometriesOverlap(Grid grid1, bool const* geometry1,
+                       Grid grid2, bool const* geometry2,
+                       int3 lo, int3 n) {
+  int ncells = n.x * n.y * n.z;
+
+  GpuBuffer<bool> d_result(1);
+  cudaLaunchReductionKernel(k_geometriesOverlap, d_result.get(),
+                            grid1, geometry1, grid2, geometry2, lo, n, ncells);
+
+  bool result;
+  checkCudaError(cudaMemcpyAsync(&result, d_result.get(), sizeof(bool),
+                                 cudaMemcpyDeviceToHost, getCudaStream()));
+  return result;
+}

--- a/src/core/reduce.hpp
+++ b/src/core/reduce.hpp
@@ -5,6 +5,7 @@
 #include "datatypes.hpp"
 
 class Field;
+class Grid;
 
 real maxAbsValue(const Field&);
 real maxVecNorm(const Field&);
@@ -14,3 +15,6 @@ std::vector<real> fieldAverage(const Field&);
 bool idxInRegions(GpuBuffer<unsigned int>, unsigned int idx);
 bool isUniformFieldComponent(const Field&, int);
 bool isUniformField(const Field&);
+bool geometriesOverlap(Grid grid1, bool const* geometry1,
+                       Grid grid2, bool const* geometry2,
+                       int3 lo, int3 n);

--- a/src/physics/mumaxworld.cpp
+++ b/src/physics/mumaxworld.cpp
@@ -15,6 +15,7 @@
 #include "magnet.hpp"
 #include "minimizer.hpp"
 #include "ncafm.hpp"
+#include "reduce.hpp"
 #include "relaxer.hpp"
 #include "shift.hpp"
 #include "system.hpp"
@@ -37,7 +38,7 @@ MumaxWorld::MumaxWorld(real3 cellsize, Grid mastergrid, int3 pbcRepetitions)
 
 MumaxWorld::~MumaxWorld() {}
 
-void MumaxWorld::checkAddibility(Grid grid, std::string name) const {
+void MumaxWorld::checkAddibility(Grid grid, GpuBuffer<bool> geometry, std::string name) const {
   if (!inMastergrid(grid)) {
       throw std::out_of_range(
           "Can not add magnet because the grid does not fit in the "
@@ -46,7 +47,7 @@ void MumaxWorld::checkAddibility(Grid grid, std::string name) const {
 
   for (const auto& namedMagnet : magnets_) {
     Magnet* m = namedMagnet.second;
-    if (grid.overlaps(m->grid())) {
+    if (MumaxWorld::overlaps(grid, geometry, m->grid(), m->system()->geometry())) {
       throw std::out_of_range(
           "Can not add magnet because it overlaps with another "
           "magnet.");
@@ -369,4 +370,36 @@ void MumaxWorld::centerDomainWall(int comp, int axis) {
         magnet->asFM()->magnetization()->set(shifted);
     }
   });
+}
+
+// --------------------------------------------------
+// Overlapping magnets
+
+bool MumaxWorld::overlaps(Grid grid1, const GpuBuffer<bool>& geometry1,
+                          Grid grid2, const GpuBuffer<bool>& geometry2) {
+  // Cheap bounding-box rejection first.
+  if (!grid1.overlaps(grid2))
+    return false;
+
+  // There is no geometry
+
+  bool hasGeo1 = geometry1.size() != 0;
+  bool hasGeo2 = geometry2.size() != 0;
+  if (!hasGeo1 && !hasGeo2)
+    return true;
+
+  int3 o1 = grid1.origin(), s1 = grid1.size();
+  int3 o2 = grid2.origin(), s2 = grid2.size();
+
+  // Overlapping box
+  int3 lo{std::max(o1.x, o2.x), std::max(o1.y, o2.y), std::max(o1.z, o2.z)};
+  int3 hi{std::min(o1.x + s1.x, o2.x + s2.x),
+          std::min(o1.y + s1.y, o2.y + s2.y),
+          std::min(o1.z + s1.z, o2.z + s2.z)};
+  int3 n{hi.x - lo.x, hi.y - lo.y, hi.z - lo.z};
+
+  // Check all cells in the overlapping box on GPU
+  return geometriesOverlap(grid1, hasGeo1 ? geometry1.get() : nullptr,
+                           grid2, hasGeo2 ? geometry2.get() : nullptr,
+                           lo, n);
 }

--- a/src/physics/mumaxworld.hpp
+++ b/src/physics/mumaxworld.hpp
@@ -38,7 +38,7 @@ class MumaxWorld : public World {
   /** Uniform bias magnetic field which will affect all magnets in the world. */
   real3 biasMagneticField;
 
-  void checkAddibility(Grid grid, std::string name) const;
+  void checkAddibility(Grid grid, GpuBuffer<bool> geometry, std::string name) const;
 
   /** Add a ferromagnet to the world. */
   Ferromagnet* addFerromagnet(Grid grid,
@@ -119,7 +119,7 @@ class MumaxWorld : public World {
     if (name.empty())
       name = prefix + "_" + std::to_string(idxUnnamed++);
     // Check if magnet can be added to this world.
-    checkAddibility(grid, name);
+    checkAddibility(grid, geometry, name);
 
     // Create the magnet and add it to this world
     auto mag = std::make_unique<T>(this, grid, name, geometry, regions);
@@ -264,6 +264,12 @@ class MumaxWorld : public World {
   // Moving simulation window
   Window& window() const { return *window_; }
   void centerDomainWall(int comp, int axis);
+
+  // --------------------------------------------------
+  
+  // Check overlapping magnets
+  static bool overlaps(Grid grid1, const GpuBuffer<bool>& geometry1,
+                       Grid grid2, const GpuBuffer<bool>& geometry2);
 
 
  private:

--- a/test/test_geometry.py
+++ b/test/test_geometry.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from mumaxplus.util.shape import Cuboid
 
 from mumaxplus import Ferromagnet, Grid, World
 
@@ -52,3 +53,44 @@ class TestGeometry:
         geomfunc = lambda x, y: True
         with pytest.raises(TypeError):
             magnet = Ferromagnet(world=world, grid=grid, geometry=geomfunc)
+
+    def test_overlap_success(self):
+        cs = 1e-9
+        world = World(cellsize=(cs, cs, cs))
+        grid = Grid((20, 20, 1))
+
+        bigside = 10*cs
+        smallside = 5*cs
+        planeside = 4*cs
+
+        bigCube = Cuboid(bigside, bigside, 2*bigside).translate(bigside, bigside, bigside)
+        smallCube = Cuboid(smallside, smallside, smallside).translate(8*cs, 8*cs, smallside)
+        plane = Cuboid(planeside, planeside, cs).translate(6*cs, 6*cs, 5*cs)
+        diff = bigCube - smallCube
+
+        magnet1 = Ferromagnet(world, grid, geometry=diff)
+        magnet2 = Ferromagnet(world, grid, geometry=plane) # or Ferromagnet(world, Grid((4, 4, 1), origin=(6, 6, 5))
+
+        assert magnet1 is not None
+        assert magnet2 is not None
+
+    def test_overlap_fail(self):
+        cs = 1e-9
+        world = World(cellsize=(cs, cs, cs))
+        grid = Grid((20, 20, 1))
+    
+        bigside = 10 * cs
+        smallside = 5 * cs
+    
+        bigCube = Cuboid(bigside, bigside, cs).translate(bigside, bigside, 0)
+        smallCube = Cuboid(smallside, smallside, cs).translate(8 * cs, 8 * cs, 0)
+        smallCubeShift = Cuboid(smallside, smallside, cs).translate(8 * cs, 9 * cs, 0)
+        diff = bigCube - smallCube
+    
+        magnet = Ferromagnet(world, grid, geometry=diff)
+    
+        with pytest.raises(Exception):
+            Ferromagnet(world, grid, geometry=smallCubeShift)
+
+
+


### PR DESCRIPTION
With this PR it should now be possible to have overlapping grids without overlapping geometries.

The function is added to `MumaxWorld` because Grid has no access to geometries. It still uses the old `Grid::overlaps` function as a quick first check to see if the grids overlap. If they do overlap it uses a GPU function in `reduce.cu` to check if geometry cells overlap.

Two tests were also added to `test_geometry`, one where the geometries don't overlap and one where they do.