### PR TITLE
Use shared step sizes for all ferromagnets in minimizer (and clean-up)

### DIFF
--- a/mumaxplus/altermagnet.py
+++ b/mumaxplus/altermagnet.py
@@ -118,7 +118,7 @@ class Altermagnet(Magnet):
         self.sub1.enable_demag = value
         self.sub2.enable_demag = value
 
-    def minimize(self, tol=1e-6, nsamples=20):
+    def minimize(self, tol=1e-6, nsamples=10):
         """Minimize the total energy.
 
         Fast energy minimization, but less robust than :func:`relax`
@@ -130,7 +130,7 @@ class Altermagnet(Magnet):
             The maximum allowed difference between consecutive magnetization
             evaluations when advancing toward an energy minimum.
 
-        nsamples : int (default=20)
+        nsamples : int (default=10)
             The number of consecutive magnetization evaluations that must not
             differ by more than the tolerance "tol".
 

--- a/mumaxplus/antiferromagnet.py
+++ b/mumaxplus/antiferromagnet.py
@@ -117,7 +117,7 @@ class Antiferromagnet(Magnet):
         self.sub1.enable_demag = value
         self.sub2.enable_demag = value
 
-    def minimize(self, tol=1e-6, nsamples=20):
+    def minimize(self, tol=1e-6, nsamples=10):
         """Minimize the total energy.
 
         Fast energy minimization, but less robust than :func:`relax`
@@ -129,7 +129,7 @@ class Antiferromagnet(Magnet):
             The maximum allowed difference between consecutive magnetization
             evaluations when advancing toward an energy minimum.
 
-        nsamples : int (default=20)
+        nsamples : int (default=10)
             The number of consecutive magnetization evaluations that must not
             differ by more than the tolerance "tol".
 

--- a/mumaxplus/ncafm.py
+++ b/mumaxplus/ncafm.py
@@ -125,7 +125,7 @@ class NcAfm(Magnet):
         self.sub2.enable_demag = value
         self.sub3.enable_demag = value
 
-    def minimize(self, tol=1e-6, nsamples=30):
+    def minimize(self, tol=1e-6, nsamples=10):
         """Minimize the total energy.
 
         Fast energy minimization, but less robust than `relax`
@@ -137,7 +137,7 @@ class NcAfm(Magnet):
             The maximum allowed difference between consecutive magnetization
             evaluations when advancing toward an energy minimum.
 
-        nsamples : int (default=30)
+        nsamples : int (default=10)
             The number of consecutive magnetization evaluations that must not
             differ by more than the tolerance "tol".
 

--- a/src/core/fieldops.hpp
+++ b/src/core/fieldops.hpp
@@ -5,12 +5,18 @@
 
 #include "field.hpp"
 
+/// y = a1*x1 + a2*x2
+void add(Field& y, real a1, const Field& x1, real a2, const Field& x2);
 /// a1*x1 + a2*x2
 Field add(real a1, const Field& x1, real a2, const Field& x2);
 
+/// y = a1*x1 + a2*x2
+void add(Field& y, real3 a1, const Field& x1, real3 a2, const Field& x2);
 /// a1*x1 + a2*x2
 Field add(real3 a1, const Field& x1, real3 a2, const Field& x2);
 
+/// positional y = a1*x1 + a2*x2
+void add(Field& y, const Field& a1, const Field& x1, const Field& a2, const Field& x2);
 /// positional a1*x1 + a2*x2
 Field add(const Field& a1, const Field& x1, const Field& a2, const Field& x2);
 

--- a/src/physics/minimizer.cu
+++ b/src/physics/minimizer.cu
@@ -87,6 +87,7 @@ __global__ void k_step(CuField mField,
   real3 m0 = m0Field.vectorAt(idx);
   real3 t = torqueField.vectorAt(idx);
 
+  // The explicit form of the implicit iteration scheme of eq. (8) in Exl et al.
   real t2 = dt * dt * dot(t, t);
   real3 m = ((4 - t2) * m0 + 4 * dt * t) / (4 + t2);
 
@@ -132,7 +133,9 @@ void Minimizer::step() {
 
   for (size_t i = 0; i < magnets_.size(); i++) {
     Field dm = add(real(+1), m1[i], real(-1), m0[i]);
-    Field dt = add(real(-1), t1[i], real(+1), t0[i]);  // TODO: check sign difference
+    Field dt = add(real(-1), t1[i], real(+1), t0[i]);  // opposite sign
+    // The Barzilai-Borwein step uses the difference in steepest ascend,
+    // while relax torque is the steepest *descend* direction.
 
     stepsizes_[i] = BarzilaiBorweinStepSize(dm, dt, nsteps_);
 

--- a/src/physics/minimizer.cu
+++ b/src/physics/minimizer.cu
@@ -93,7 +93,7 @@ __global__ void k_step(CuField mField,
   mField.setVectorInCell(idx, m);
 }
 
-static inline real BarzilianBorweinStepSize(Field& dm, Field& dtorque, int n) {
+static inline real BarzilaiBorweinStepSize(Field& dm, Field& dtorque, int n) {
   real nom, div;
   if (n % 2 == 0) {
     nom = dotSum(dm, dm);
@@ -134,7 +134,7 @@ void Minimizer::step() {
     Field dm = add(real(+1), m1[i], real(-1), m0[i]);
     Field dt = add(real(-1), t1[i], real(+1), t0[i]);  // TODO: check sign difference
 
-    stepsizes_[i] = BarzilianBorweinStepSize(dm, dt, nsteps_);
+    stepsizes_[i] = BarzilaiBorweinStepSize(dm, dt, nsteps_);
 
     addMagDiff(maxVecNorm(dm));
   }

--- a/src/physics/minimizer.cu
+++ b/src/physics/minimizer.cu
@@ -131,8 +131,10 @@ void Minimizer::step() {
     t1[i] = torques_[i].eval();
 
   for (size_t i = 0; i < magnets_.size(); i++) {
-    Field dm = add(real(+1), m1[i], real(-1), m0[i]);
-    Field dt = add(real(-1), t1[i], real(+1), t0[i]);  // opposite sign
+    // Reuse m0 and t0 for efficiency, but declare alias for clarity
+    Field &dm = m0[i], &dt = t0[i];
+    add(dm, real(+1), m1[i], real(-1), m0[i]);
+    add(dt, real(-1), t1[i], real(+1), t0[i]);  // opposite sign
     // The Barzilai-Borwein step uses the difference in steepest ascend,
     // while relax torque is the steepest *descend* direction.
 

--- a/src/physics/minimizer.cu
+++ b/src/physics/minimizer.cu
@@ -20,7 +20,7 @@ Minimizer::Minimizer(const Ferromagnet* magnet,
       t1(1),
       m0(1),
       m1(1) {
-  stepsizes_ = {1e-14};  // TODO: figure out how to make descent guess
+  stepsize_ = 1e-14;  // TODO: figure out how to make descent guess
   // TODO: check if input arguments are sane
 }
 
@@ -34,7 +34,7 @@ Minimizer::Minimizer(const HostMagnet* magnet,
       t1(magnets_.size()),
       m0(magnets_.size()),
       m1(magnets_.size()) {
-  stepsizes_.assign(magnets_.size(), 1e-14);
+  stepsize_ = 1e-14;
   for (auto sub : magnets_)
     torques_.push_back(relaxTorqueQuantity(sub));
 }
@@ -56,15 +56,14 @@ Minimizer::Minimizer(const MumaxWorld* world,
   for (auto magnet : magnets_)
     torques_.push_back(relaxTorqueQuantity(magnet));
 
-  size_t N = magnets_.size();
-  nMagDiffSamples_ = nMagDiffSamples * N;
+  nMagDiffSamples_ = nMagDiffSamples;
+  stepsize_ = 1e-14;
 
+  size_t N = magnets_.size();
   t0.resize(N);
   t1.resize(N);
   m0.resize(N);
   m1.resize(N);
-    
-  stepsizes_.assign(N, 1e-14);
 }
       
 void Minimizer::exec() {
@@ -93,15 +92,19 @@ __global__ void k_step(CuField mField,
   mField.setVectorInCell(idx, m);
 }
 
-static inline real BarzilaiBorweinStepSize(Field& dm, Field& dtorque, int n) {
-  real nom, div;
-  if (n % 2 == 0) {
-    nom = dotSum(dm, dm);
-    div = dotSum(dm, dtorque);
-  } else {
-    nom = dotSum(dm, dtorque);
-    div = dotSum(dtorque, dtorque);
+static inline real BarzilaiBorweinStepSize(std::vector<Field>& dm,
+                                           std::vector<Field>& dtorque, int n) {
+  real nom = 0, div = 0;
+  for (size_t i = 0; i < dm.size(); i++) {
+    if (n % 2 == 0) {
+      nom += dotSum(dm[i], dm[i]);
+      div += dotSum(dm[i], dtorque[i]);
+    } else {
+      nom += dotSum(dm[i], dtorque[i]);
+      div += dotSum(dtorque[i], dtorque[i]);
+    }
   }
+
   if (div == 0.0)
     return 1e-14;  // TODO: figure out safe stepsize
 
@@ -121,7 +124,7 @@ void Minimizer::step() {
     }
 
     int ncells = m1[i].grid().ncells();
-    cudaLaunch(ncells, k_step, m1[i].cu(), m0[i].cu(), t0[i].cu(), stepsizes_[i]);
+    cudaLaunch(ncells, k_step, m1[i].cu(), m0[i].cu(), t0[i].cu(), stepsize_);
   }
   
   for (size_t i = 0; i < magnets_.size(); i++)
@@ -130,18 +133,21 @@ void Minimizer::step() {
   for (size_t i = 0; i < magnets_.size(); i++)
     t1[i] = torques_[i].eval();
 
+  // Reuse m0 and t0 for efficiency, but declare alias for clarity
+  std::vector<Field> &dm = m0, &dt = t0;
+  real magDiff = 0;
   for (size_t i = 0; i < magnets_.size(); i++) {
-    // Reuse m0 and t0 for efficiency, but declare alias for clarity
-    Field &dm = m0[i], &dt = t0[i];
-    add(dm, real(+1), m1[i], real(-1), m0[i]);
-    add(dt, real(-1), t1[i], real(+1), t0[i]);  // opposite sign
+    add(dm[i], real(+1), m1[i], real(-1), m0[i]);
+    add(dt[i], real(-1), t1[i], real(+1), t0[i]);  // opposite sign
     // The Barzilai-Borwein step uses the difference in steepest ascend,
     // while relax torque is the steepest *descend* direction.
 
-    stepsizes_[i] = BarzilaiBorweinStepSize(dm, dt, nsteps_);
-
-    addMagDiff(maxVecNorm(dm));
+    magDiff = std::max(magDiff, maxVecNorm(dm[i]));
   }
+
+  stepsize_ = BarzilaiBorweinStepSize(dm, dt, nsteps_);
+  addMagDiff(magDiff);
+
   nsteps_ += 1;
 }
 

--- a/src/physics/minimizer.cu
+++ b/src/physics/minimizer.cu
@@ -139,8 +139,8 @@ void Minimizer::step() {
   for (size_t i = 0; i < magnets_.size(); i++) {
     add(dm[i], real(+1), m1[i], real(-1), m0[i]);
     add(dt[i], real(-1), t1[i], real(+1), t0[i]);  // opposite sign
-    // The Barzilai-Borwein step uses the difference in steepest ascend,
-    // while relax torque is the steepest *descend* direction.
+    // The Barzilai-Borwein step uses the difference in steepest ascent,
+    // while relax torque is the steepest *descent* direction.
 
     magDiff = std::max(magDiff, maxVecNorm(dm[i]));
   }

--- a/src/physics/minimizer.cu
+++ b/src/physics/minimizer.cu
@@ -43,16 +43,7 @@ Minimizer::Minimizer(const MumaxWorld* world,
                      real stopMaxMagDiff,
                      int nMagDiffSamples)
     : stopMaxMagDiff_(stopMaxMagDiff) {
-  // Total number of ferromagnets (FM instances or sublattices)
-  size_t N = world->ferromagnets().size() + 2 * world->antiferromagnets().size();
-  
-  nMagDiffSamples_ = nMagDiffSamples * N;
-
-  t0.resize(N);
-  t1.resize(N);
-  m0.resize(N);
-  m1.resize(N);
-
+  // Find all ferromagnets (FM instances or sublattices)
   for (const auto pair : world->magnets()) {
     if (auto host = pair.second->asHost()) {
       for (auto sub : host->sublattices())
@@ -64,6 +55,14 @@ Minimizer::Minimizer(const MumaxWorld* world,
 
   for (auto magnet : magnets_)
     torques_.push_back(relaxTorqueQuantity(magnet));
+
+  size_t N = magnets_.size();
+  nMagDiffSamples_ = nMagDiffSamples * N;
+
+  t0.resize(N);
+  t1.resize(N);
+  m0.resize(N);
+  m1.resize(N);
     
   stepsizes_.assign(N, 1e-14);
 }

--- a/src/physics/minimizer.cu
+++ b/src/physics/minimizer.cu
@@ -113,14 +113,14 @@ void Minimizer::step() {
 
     m0[i] = magnets_[i]->magnetization()->eval();
 
-    if (nsteps_ == 0)
+    if (nsteps_ == 0) {
       t0[i] = torques_[i].eval();
-    else
+      m1[i] = Field(magnets_[i]->system(), 3);
+    } else {
       t0[i] = t1[i];
+    }
 
-    m1[i] = Field(magnets_[i]->system(), 3);
     int ncells = m1[i].grid().ncells();
-
     cudaLaunch(ncells, k_step, m1[i].cu(), m0[i].cu(), t0[i].cu(), stepsizes_[i]);
   }
   

--- a/src/physics/minimizer.hpp
+++ b/src/physics/minimizer.hpp
@@ -20,7 +20,7 @@ class Minimizer {
  private:
   void step();
   std::vector<const Ferromagnet*> magnets_;
-  std::vector<real> stepsizes_;
+  real stepsize_;
   int nsteps_;
 
   std::vector<FM_FieldQuantity> torques_;


### PR DESCRIPTION
This PR has multiple small changes in the same couple of files. The biggest change is the shared step size. Most of my time was spent testing.

# Shared step size
The original [paper of Exl et al.](https://doi.org/10.1063/1.4862839) uses one "uniform" scalar step size for all magnetizations in a ferromagnet. I wondered if it would be better to share the step size between different linked ferromagnetic instances as well. There are two possibilities:
- ferromagnets linked by stray fields
- ferromagnets as sublattices

For the first case, I tested the MFM example, which has 2 ferromagnets in a plane. The minimization time went from 7.224 s to 8.294 s or about 15% slower for the same final state.

I also tested the multilayer example, which has 4 ferromagnets in a plane. It now takes 4.098 s instead of 3.520 s, or about 20% slower, ***but*** the final state has a lower energy. (Any comment I made about instability before was a bug in my benchmarking script.)

Without shared step:
<img width="1120" height="530" alt="tweaks_multilayer" src="https://github.com/user-attachments/assets/1b0ed543-dc5d-420d-9094-71dcab2a814a" />
With shared step:
<img width="1120" height="530" alt="shared-step_multilayer" src="https://github.com/user-attachments/assets/dc7aec50-a598-4c66-a035-b711028ed6a7" />
So *in this particular case* a shared step is better (even though it is slower).

For the sublattices I first tested the altermagnetic Bloch wall example. The final state is the same, but the minimization time went from 1.813 s to 0.2836 s or 85% less! I also tested an altermagnetic skyrmion, which went from 12.97 s to 2.62 s or 80% less time for the same final state.

This felt like enough evidence in favor of this change.

I also changed all default `nsamples` to 10 everywhere, but changed the convergence check as well. So instead of checking 2 sublattices a total of 20 times, it checks everything together 10 times.

# Clean-up and speed-up
I also fixed some typos and clarified some mysteries with comments. Most importantly, I borrowed some tricks from mumax3 to speed up the code slightly. All previous "before-times" were with this speed-up already in place.
- Reuse `m0` and `t0` as `dm` and `dt`. This eliminates 2 field creations.
- Also use `add(dm, ...)` instead of `dm = add(...)`. This eliminates 1 field creation.
- Only initialize `m1` once.
I tested these with standard problem 2, which minimizes a variety of system sizes. Unchanged is blue, the first 2 changes are orange and all changes together are green. I did not test the 'shared step' version here, but it should not perform meaningfully different here.

<img width="640" height="719" alt="compare_bench_stdp2" src="https://github.com/user-attachments/assets/dcdadb84-fdac-4b2f-983f-196191184269" />

These changes make it up to 10% faster for small systems and about 1% faster for large systems. They do not alter the final state.